### PR TITLE
Use single multi channel bus for monitoring plugins

### DIFF
--- a/ear-production-suite/plugins/monitoring/src/monitoring_plugin_processor.cpp
+++ b/ear-production-suite/plugins/monitoring/src/monitoring_plugin_processor.cpp
@@ -33,9 +33,7 @@ EarMonitoringAudioProcessor::_getBusProperties() {
   channels_ = layout.channelNames().size();
   auto ret = BusesProperties().withInput(
       "Input", AudioChannelSet::discreteChannels(64), true);
-  for (const std::string& name : layout.channelNames()) {
-    ret = ret.withOutput(name, AudioChannelSet::mono(), true);
-  }
+  ret = ret.withOutput("Output", AudioChannelSet::discreteChannels(layout.channels().size()), true);
   return ret;
 }
 


### PR DESCRIPTION
Switching from multiple mono output busses to a single multi-channel bus for broader
DAW compatibility