### PR TITLE
Element overview causes gui lag with lots of metadata

### DIFF
--- a/ear-production-suite/plugins/scene/src/element_overview.hpp
+++ b/ear-production-suite/plugins/scene/src/element_overview.hpp
@@ -309,11 +309,11 @@ class ElementOverview : public Component, private Timer {
     overviewUpdate_ = !overviewUpdate_;
 
     if (overviewUpdate_ == false) {
-      rotateLeftButton_->onClick = nullptr;
-      rotateRightButton_->onClick = nullptr;
+      rotateLeftButton_->setEnabled(false);
+      rotateRightButton_->setEnabled(false);
     } else {
-      rotateLeftButton_->onClick = [this]() { this->rotate(90.f); };
-      rotateRightButton_->onClick = [this]() { this->rotate(-90.f); };
+      rotateLeftButton_->setEnabled(true);
+      rotateRightButton_->setEnabled(true);
     }
   }
 


### PR DESCRIPTION
This pull request tries to mitigate the lag with lots of metadata.
It introduces a dirty flag to the ElementOverview that prevents copying the programme and the itemStore and skips triggering a repaint of the ElementOverview when an pending repaint call exists. It also disables/enables the ElementOverview by clicking on it.
The suite has to be compiled as Relese to get the full effect. Also the VU meter update frequency in REAPER should be increased.
