### PR TITLE
Avoid deprecated GitHub Actions commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,18 +73,25 @@ jobs:
           file(DOWNLOAD "${ccache_url}" ./ccache.tar.xz SHOW_PROGRESS)
           execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ccache.tar.xz)
         working-directory: ${{ runner.workspace }}
+        
+      - name: 'Config env for ccache on windows'
+        if: matrix.config.os == 'windows-latest'
+        run: |
+          echo "${{ runner.workspace }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CCACHE_DIR=${{ github.workspace }}/.ccache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       
       - name: 'Install ccache on macos'
         if: matrix.config.os == 'macos-latest'
-        run: brew install ccache
-      
-      - name: 'Add ccache to path'
-        run: echo "::add-path::${{ runner.workspace }}"
-        
-      - name: 'Set ccache config'
         run: |
-          echo "::set-env name=CCACHE_BASEDIR::${{ github.workspace }}"
-          echo "::set-env name=CCACHE_DIR::${{ runner.workspace }}/.ccache"
+          brew install ccache
+          
+      - name: 'Config env for ccache on macos'
+        if: matrix.config.os == 'macos-latest'
+        run: |
+          echo "${{ runner.workspace }}" >> $GITHUB_PATH
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
           
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp


### PR DESCRIPTION
set-env and add-path: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/