### PR TITLE
Avoid hitting assertion on Reaper close

### DIFF
--- a/ear-production-suite/plugins/scene/src/nng_wrappers.h
+++ b/ear-production-suite/plugins/scene/src/nng_wrappers.h
@@ -327,7 +327,7 @@ class CommandReceiver : public SocketBaseForListeners, public CommandCommon {
 
       case RECV:
         resAioRes = nng_aio_result(aio);
-        if (resAioRes == NNG_ECANCELED) break;
+        if (resAioRes == NNG_ECANCELED || resAioRes == NNG_ECLOSED) break;
         assert(resAioRes == 0);
 
         nngMsg = nng_aio_get_msg(aio);


### PR DESCRIPTION
Break if nng aio result is ECLOSED to avoid hitting assertion when Reaper is closed (macOS)