### PR TITLE
#37 Highlight Settings Button

### DIFF
--- a/ear-production-suite/plugins/scene/src/object_view.hpp
+++ b/ear-production-suite/plugins/scene/src/object_view.hpp
@@ -124,8 +124,6 @@ class ObjectView : public ElementView,
     positionInteractionSettings_->distanceMinSlider->addListener(this);
     positionInteractionSettings_->distanceMaxSlider->addListener(this);
     addAndMakeVisible(positionInteractionPanel_.get());
-            
-    settingsButtonBackgroundColour = settingsButton_->findColour(EarButton::backgroundColourId);
 
     updateDesiredHeight();
   }
@@ -339,7 +337,9 @@ class ObjectView : public ElementView,
   }
 
   void notifyDataChange() {
-    const Colour col = (data_.object.mutable_interactive_gain()->enabled() || data_.object.mutable_interactive_on_off()->enabled() || data_.object.mutable_interactive_position()->enabled()) ? Colours::orange : settingsButtonBackgroundColour;
+    const Colour col = (data_.object.mutable_interactive_gain()->enabled() ||
+                        data_.object.mutable_interactive_on_off()->enabled() ||
+                        data_.object.mutable_interactive_position()->enabled()) ? EarColours::SettingsButtonInteractivity : EarColours::Area01dp;
                                            
     settingsButton_->setColour(EarButton::backgroundColourId, col);
     
@@ -399,8 +399,6 @@ class ObjectView : public ElementView,
   ObjectType objectType_;
 
   ListenerList<Listener> listeners_;
-                       
-  Colour settingsButtonBackgroundColour{Colours::black};
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ObjectView)
 };

--- a/ear-production-suite/plugins/scene/src/object_view.hpp
+++ b/ear-production-suite/plugins/scene/src/object_view.hpp
@@ -124,6 +124,8 @@ class ObjectView : public ElementView,
     positionInteractionSettings_->distanceMinSlider->addListener(this);
     positionInteractionSettings_->distanceMaxSlider->addListener(this);
     addAndMakeVisible(positionInteractionPanel_.get());
+            
+    settingsButtonBackgroundColour = settingsButton_->findColour(EarButton::backgroundColourId);
 
     updateDesiredHeight();
   }
@@ -337,6 +339,10 @@ class ObjectView : public ElementView,
   }
 
   void notifyDataChange() {
+    const Colour col = (data_.object.mutable_interactive_gain()->enabled() || data_.object.mutable_interactive_on_off()->enabled() || data_.object.mutable_interactive_position()->enabled()) ? Colours::orange : settingsButtonBackgroundColour;
+                                           
+    settingsButton_->setColour(EarButton::backgroundColourId, col);
+    
     Component::BailOutChecker checker(this);
     listeners_.callChecked(
         checker, [&](Listener& l) { l.objectDataChanged(this->data_); });
@@ -393,6 +399,8 @@ class ObjectView : public ElementView,
   ObjectType objectType_;
 
   ListenerList<Listener> listeners_;
+                       
+  Colour settingsButtonBackgroundColour{Colours::black};
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ObjectView)
 };

--- a/ear-production-suite/plugins/scene/src/object_view.hpp
+++ b/ear-production-suite/plugins/scene/src/object_view.hpp
@@ -90,6 +90,7 @@ class ObjectView : public ElementView,
       data_.object.mutable_interactive_on_off()->set_enabled(
           this->onOffInteractionPanel_->isExpanded());
       this->notifyDataChange();
+      updateSettingsButtonColour();
     };
     addAndMakeVisible(onOffInteractionPanel_.get());
 
@@ -100,6 +101,7 @@ class ObjectView : public ElementView,
       data_.object.mutable_interactive_gain()->set_enabled(
           this->gainInteractionPanel_->isExpanded());
       this->notifyDataChange();
+      updateSettingsButtonColour();
     };
     gainInteractionSettings_->gainSliderRange->addListener(this);
     gainInteractionSettings_->gainMinSlider->addListener(this);
@@ -113,6 +115,7 @@ class ObjectView : public ElementView,
       data_.object.mutable_interactive_position()->set_enabled(
           this->positionInteractionPanel_->isExpanded());
       this->notifyDataChange();
+      updateSettingsButtonColour();
     };
     positionInteractionSettings_->azimuthSliderRange->addListener(this);
     positionInteractionSettings_->azimuthMinSlider->addListener(this);
@@ -145,6 +148,8 @@ class ObjectView : public ElementView,
 
     settingsButton_->setToggleState(data_.object.show_settings(),
                                     dontSendNotification);
+    updateSettingsButtonColour();
+    
     onOffInteractionPanel_->setVisible(this->settingsButton_->getToggleState());
     gainInteractionPanel_->setVisible(this->settingsButton_->getToggleState());
     positionInteractionPanel_->setVisible(
@@ -337,18 +342,20 @@ class ObjectView : public ElementView,
   }
 
   void notifyDataChange() {
-    const Colour col = (data_.object.mutable_interactive_gain()->enabled() ||
-                        data_.object.mutable_interactive_on_off()->enabled() ||
-                        data_.object.mutable_interactive_position()->enabled()) ? EarColours::SettingsButtonInteractivity : EarColours::Area01dp;
-                                           
-    settingsButton_->setColour(EarButton::backgroundColourId, col);
-    
     Component::BailOutChecker checker(this);
     listeners_.callChecked(
         checker, [&](Listener& l) { l.objectDataChanged(this->data_); });
     if (checker.shouldBailOut()) {
       return;
     }
+  }
+  
+  void updateSettingsButtonColour() {
+    const Colour col = (data_.object.mutable_interactive_gain()->enabled() ||
+                        data_.object.mutable_interactive_on_off()->enabled() ||
+                        data_.object.mutable_interactive_position()->enabled()) ? EarColours::SettingsButtonInteraction : EarColours::Area01dp;
+                                           
+    settingsButton_->setColour(EarButton::backgroundColourId, col);
   }
 
   void updateDesiredHeight() {

--- a/ear-production-suite/plugins/shared/components/look_and_feel/colours.hpp
+++ b/ear-production-suite/plugins/shared/components/look_and_feel/colours.hpp
@@ -47,6 +47,7 @@ static const Colour HeaderText = Colour(0, 0, 0).withAlpha(0.87f);
 static const Colour ComboBoxPopupBackground = Colour(49, 49, 49);
 static const Colour ObjectItemBackground = Colour(30, 30, 30);
 static const Colour Sphere = Colour(90, 90, 90);
+static const Colour SettingsButtonInteractivity = Colours::orange.withMultipliedBrightness(0.6f);
 
 static const Colour Item01 = Colour(255, 131, 111);
 static const Colour Item02 = Colour(255, 255, 128);

--- a/ear-production-suite/plugins/shared/components/look_and_feel/colours.hpp
+++ b/ear-production-suite/plugins/shared/components/look_and_feel/colours.hpp
@@ -47,7 +47,6 @@ static const Colour HeaderText = Colour(0, 0, 0).withAlpha(0.87f);
 static const Colour ComboBoxPopupBackground = Colour(49, 49, 49);
 static const Colour ObjectItemBackground = Colour(30, 30, 30);
 static const Colour Sphere = Colour(90, 90, 90);
-static const Colour SettingsButtonInteractivity = Colours::orange.withMultipliedBrightness(0.6f);
 
 static const Colour Item01 = Colour(255, 131, 111);
 static const Colour Item02 = Colour(255, 255, 128);
@@ -65,6 +64,8 @@ static const Colour Item12 = Colour(49, 142, 61);
 static const std::vector<Colour> Items{Item01, Item02, Item03, Item04,
                                        Item05, Item06, Item07, Item08,
                                        Item09, Item10, Item11, Item12};
+
+static const Colour SettingsButtonInteractivity = Item07.withMultipliedBrightness(0.75f);
 
 }  // namespace EarColours
 

--- a/ear-production-suite/plugins/shared/components/look_and_feel/colours.hpp
+++ b/ear-production-suite/plugins/shared/components/look_and_feel/colours.hpp
@@ -65,7 +65,7 @@ static const std::vector<Colour> Items{Item01, Item02, Item03, Item04,
                                        Item05, Item06, Item07, Item08,
                                        Item09, Item10, Item11, Item12};
 
-static const Colour SettingsButtonInteractivity = Item07.withMultipliedBrightness(0.75f);
+static const Colour SettingsButtonInteraction = Item07.withMultipliedBrightness(0.75f);
 
 }  // namespace EarColours
 


### PR DESCRIPTION
Button now has a different color when interactivity is enabled. Since the suggested yellow didn't work great with the white text, i went for a darker orange instead. Colour needs to be adjusted later in colours.hpp.

Fixes #37