### PR TITLE
#44 Export - use JumpPosition

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/exportaction_parameterprocessing.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_parameterprocessing.cpp
@@ -548,6 +548,11 @@ std::optional<std::vector<std::shared_ptr<adm::AudioBlockFormatObjects>>> Cumula
                 block->set((adm::Rtime)rtime);
                 block->set((adm::Duration)duration);
 
+                // Use JumpPosition for second block if multiple points at same position
+                if (multipleValuesForSingleParameterAtTime(*timeIt) && processBack) {
+                    block->set(adm::JumpPosition((adm::JumpPositionFlag)true));
+                }
+
                 blocks.push_back(block);
             }
 


### PR DESCRIPTION
As discussed to fix #44, for blocks with zero-duration a JumpPosition flag should be set. If there are multiple points at the same timestamp, the current implementation always creates 2 blocks, where the second block has zero-duration and by using the already existing flags, a JumpPosition for this block can be set.