### PR TITLE
Removing elements from programme store is done by frontend connector,…

### DIFF
--- a/ear-production-suite/lib/src/scene_backend.cpp
+++ b/ear-production-suite/lib/src/scene_backend.cpp
@@ -30,6 +30,7 @@ SceneBackend::~SceneBackend() { metadataSender_.asyncStop(); }
 communication::MessageBuffer SceneBackend::getMessage() {
   std::lock_guard<std::mutex> lock(storeMutex_);
   if (rebuildSceneStore_) {
+    rebuildSceneStore_ = false;
     updateSceneStore();
   }
   communication::MessageBuffer buffer =

--- a/ear-production-suite/plugins/object/src/object_frontend_connector.cpp
+++ b/ear-production-suite/plugins/object/src/object_frontend_connector.cpp
@@ -466,71 +466,73 @@ void ObjectsJuceFrontendConnector::setRange(float range) {
 
 void ObjectsJuceFrontendConnector::parameterValueChanged(int parameterIndex,
                                                          float newValue) {
-  using ParameterId = ui::ObjectsFrontendBackendConnector::ParameterId;
-  switch (parameterIndex) {
-    case 0:
-      notifyParameterChanged(ParameterId::ROUTING, p_->getRouting()->get());
-      setRouting(p_->getRouting()->get());
-      break;
-    case 1:
-      notifyParameterChanged(ParameterId::GAIN,
-                             Decibels::decibelsToGain(p_->getGain()->get()));
-      setGain(p_->getGain()->get());
-      break;
-    case 2:
-      notifyParameterChanged(ParameterId::AZIMUTH, p_->getAzimuth()->get());
-      setAzimuth(p_->getAzimuth()->get());
-      break;
-    case 3:
-      notifyParameterChanged(ParameterId::ELEVATION, p_->getElevation()->get());
-      setElevation(p_->getElevation()->get());
-      break;
-    case 4:
-      notifyParameterChanged(ParameterId::DISTANCE, p_->getDistance()->get());
-      setDistance(p_->getDistance()->get());
-      break;
-    case 5:
-      setLinkSize(p_->getLinkSize()->get());
-      break;
-    case 6:
-      setSize(p_->getSize()->get());
-      break;
-    case 7:
-      notifyParameterChanged(ParameterId::WIDTH, p_->getWidth()->get() * 360.f);
-      setWidth(p_->getWidth()->get());
-      break;
-    case 8:
-      notifyParameterChanged(ParameterId::HEIGHT,
-                             p_->getHeight()->get() * 360.f);
-      setHeight(p_->getHeight()->get());
-      break;
-    case 9:
-      notifyParameterChanged(ParameterId::DEPTH, p_->getDepth()->get());
-      setDepth(p_->getDepth()->get());
-      break;
-    case 10:
-      notifyParameterChanged(ParameterId::DIFFUSE, p_->getDiffuse()->get());
-      setDiffuse(p_->getDiffuse()->get());
-      break;
-    case 11:
-      setDivergence(p_->getDivergence()->get());
-      if (p_->getDivergence()->get()) {
+  updater_.callOnMessageThread([this, parameterIndex, newValue]() {
+    using ParameterId = ui::ObjectsFrontendBackendConnector::ParameterId;
+    switch (parameterIndex) {
+      case 0:
+        notifyParameterChanged(ParameterId::ROUTING, p_->getRouting()->get());
+        setRouting(p_->getRouting()->get());
+        break;
+      case 1:
+        notifyParameterChanged(ParameterId::GAIN,
+                               Decibels::decibelsToGain(p_->getGain()->get()));
+        setGain(p_->getGain()->get());
+        break;
+      case 2:
+        notifyParameterChanged(ParameterId::AZIMUTH, p_->getAzimuth()->get());
+        setAzimuth(p_->getAzimuth()->get());
+        break;
+      case 3:
+        notifyParameterChanged(ParameterId::ELEVATION, p_->getElevation()->get());
+        setElevation(p_->getElevation()->get());
+        break;
+      case 4:
+        notifyParameterChanged(ParameterId::DISTANCE, p_->getDistance()->get());
+        setDistance(p_->getDistance()->get());
+        break;
+      case 5:
+        setLinkSize(p_->getLinkSize()->get());
+        break;
+      case 6:
+        setSize(p_->getSize()->get());
+        break;
+      case 7:
+        notifyParameterChanged(ParameterId::WIDTH, p_->getWidth()->get() * 360.f);
+        setWidth(p_->getWidth()->get());
+        break;
+      case 8:
+        notifyParameterChanged(ParameterId::HEIGHT,
+                               p_->getHeight()->get() * 360.f);
+        setHeight(p_->getHeight()->get());
+        break;
+      case 9:
+        notifyParameterChanged(ParameterId::DEPTH, p_->getDepth()->get());
+        setDepth(p_->getDepth()->get());
+        break;
+      case 10:
+        notifyParameterChanged(ParameterId::DIFFUSE, p_->getDiffuse()->get());
+        setDiffuse(p_->getDiffuse()->get());
+        break;
+      case 11:
+        setDivergence(p_->getDivergence()->get());
+        if (p_->getDivergence()->get()) {
+          notifyParameterChanged(ParameterId::FACTOR, p_->getFactor()->get());
+          notifyParameterChanged(ParameterId::RANGE, p_->getRange()->get());
+        } else {
+          notifyParameterChanged(ParameterId::FACTOR, 0.f);
+          notifyParameterChanged(ParameterId::RANGE, 0.f);
+        }
+        break;
+      case 12:
         notifyParameterChanged(ParameterId::FACTOR, p_->getFactor()->get());
+        setFactor(p_->getFactor()->get());
+        break;
+      case 13:
         notifyParameterChanged(ParameterId::RANGE, p_->getRange()->get());
-      } else {
-        notifyParameterChanged(ParameterId::FACTOR, 0.f);
-        notifyParameterChanged(ParameterId::RANGE, 0.f);
-      }
-      break;
-    case 12:
-      notifyParameterChanged(ParameterId::FACTOR, p_->getFactor()->get());
-      setFactor(p_->getFactor()->get());
-      break;
-    case 13:
-      notifyParameterChanged(ParameterId::RANGE, p_->getRange()->get());
-      setRange(p_->getRange()->get());
-      break;
-  }
+        setRange(p_->getRange()->get());
+        break;
+    }
+  });
 }
 
 void ObjectsJuceFrontendConnector::trackPropertiesChanged(

--- a/ear-production-suite/plugins/scene/src/scene_frontend_connector.cpp
+++ b/ear-production-suite/plugins/scene/src/scene_frontend_connector.cpp
@@ -439,6 +439,16 @@ void JuceSceneFrontendConnector::removeFromProgrammes(
       }
     }
   }
+  else {
+    auto* prog = p_->getProgrammeStore()->mutable_programme(p_->getProgrammeStore()->selected_programme_index());
+    for(int elementPos = 0; elementPos < prog->element().size(); ++elementPos) {
+        if(communication::ConnectionId(prog->element(elementPos).object().connection_id()) == id) {
+            prog->mutable_element()->erase(prog->mutable_element()->begin() + elementPos);
+            break;
+        }
+    }
+    notifyProgrammeStoreChanged(p_->getProgrammeStoreCopy());
+  }
 }
 
 void JuceSceneFrontendConnector::removeFromObjectViews(

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -201,8 +201,7 @@ void EarVstExportSources::generateAdmAndChna(ReaperAPI const& api)
                     for (auto& newError : newErrors) {
                         warningStrings.push_back(newError.what());
                     }
-                }
-                else if(param && env) {
+                } else if(param && env) {
                     // We have an envelope for this ADM parameter
                     auto newErrors = cumulatedPointData.useEnvelopeDataForParameter(*env, *param, admParameter, api);
                     for(auto &newError : newErrors) {
@@ -367,16 +366,18 @@ std::optional<double> EarVstExportSources::getValueFor(std::shared_ptr<admplug::
 bool EarVstExportSources::getEnvelopeBypassed(TrackEnvelope* env, ReaperAPI const& api)
 {
     bool envBypassed = false;
-    char chunk[1024]; // For a plugin parameter (PARMENV) the ACT flag should always be within the first couple bytes of the state chunk
-    bool getRes = api.GetEnvelopeStateChunk(env, chunk, 1024, false);
-    if (getRes) {
-        std::istringstream chunkSs(chunk);
-        std::string line;
-        while (std::getline(chunkSs, line)) {
-            auto activePos = line.rfind("ACT ", 0);
-            if ((activePos != std::string::npos) && (line.size() > (activePos + 4))) {
-                envBypassed = line.at(activePos + 4) == '0';
-                break;
+    if(env) {
+        char chunk[1024]; // For a plugin parameter (PARMENV) the ACT flag should always be within the first couple bytes of the state chunk
+        bool getRes = api.GetEnvelopeStateChunk(env, chunk, 1024, false);
+        if (getRes) {
+            std::istringstream chunkSs(chunk);
+            std::string line;
+            while (std::getline(chunkSs, line)) {
+                auto activePos = line.rfind("ACT ", 0);
+                if ((activePos != std::string::npos) && (line.size() > (activePos + 4))) {
+                    envBypassed = line.at(activePos + 4) == '0';
+                    break;
+                }
             }
         }
     }

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -367,16 +367,15 @@ std::optional<double> EarVstExportSources::getValueFor(std::shared_ptr<admplug::
 bool EarVstExportSources::getEnvelopeBypassed(TrackEnvelope* env, ReaperAPI const& api)
 {
     bool envBypassed = false;
-    char chunk[1024]; // A new envelope should only be about 100 bytes
+    char chunk[1024]; // For a plugin parameter (PARMENV) the ACT flag should always be within the first couple bytes of the state chunk
     bool getRes = api.GetEnvelopeStateChunk(env, chunk, 1024, false);
     if (getRes) {
         std::istringstream chunkSs(chunk);
         std::string line;
         while (std::getline(chunkSs, line)) {
             auto activePos = line.rfind("ACT ", 0);
-            if (activePos != std::string::npos) {
-                auto active = static_cast<int>(line.at(activePos + 4)) - 48;
-                envBypassed = !active;
+            if ((activePos != std::string::npos) && (line.size() > (activePos + 4))) {
+                envBypassed = line.at(activePos + 4) == '0';
                 break;
             }
         }

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -194,7 +194,6 @@ void EarVstExportSources::generateAdmAndChna(ReaperAPI const& api)
                 auto param = pluginSuite->getParameterFor(admParameter);
                 auto env = getEnvelopeFor(pluginSuite, pluginInst.get(), admParameter, api);
                 
-                //DEBUG IAL
                 if (getEnvelopeBypassed(env, api)) { 
                     // We have an envelope, but it is bypassed
                     auto val = getValueFor(pluginSuite, pluginInst.get(), admParameter, api);
@@ -204,7 +203,6 @@ void EarVstExportSources::generateAdmAndChna(ReaperAPI const& api)
                     }
                 }
                 else if(param && env) {
-                //DEBUG IAL
                     // We have an envelope for this ADM parameter
                     auto newErrors = cumulatedPointData.useEnvelopeDataForParameter(*env, *param, admParameter, api);
                     for(auto &newError : newErrors) {

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -364,29 +364,25 @@ std::optional<double> EarVstExportSources::getValueFor(std::shared_ptr<admplug::
     return std::optional<double>();
 }
 
-//TODO IAL
 bool EarVstExportSources::getEnvelopeBypassed(TrackEnvelope* env, ReaperAPI const& api)
 {
     bool envBypassed = false;
     char chunk[1024]; // A new envelope should only be about 100 bytes
     bool getRes = api.GetEnvelopeStateChunk(env, chunk, 1024, false);
-    if (getRes)
-    {
+    if (getRes) {
         std::istringstream chunkSs(chunk);
         std::string line;
-        while (std::getline(chunkSs, line))
-        {
+        while (std::getline(chunkSs, line)) {
             auto activePos = line.rfind("ACT ", 0);
-            if (activePos != std::string::npos)
-            {
+            if (activePos != std::string::npos) {
                 auto active = static_cast<int>(line[activePos + 4]) - 48;
                 envBypassed = !active;
+                break;
             }
         }
     }
     return envBypassed;
 }
-//TODO IAL
 
 std::vector<std::shared_ptr<PluginInstance>> EarVstExportSources::getEarInputPluginsWithTrackMapping(int trackMapping, ReaperAPI const& api)
 {

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -375,7 +375,7 @@ bool EarVstExportSources::getEnvelopeBypassed(TrackEnvelope* env, ReaperAPI cons
         while (std::getline(chunkSs, line)) {
             auto activePos = line.rfind("ACT ", 0);
             if (activePos != std::string::npos) {
-                auto active = static_cast<int>(line[activePos + 4]) - 48;
+                auto active = static_cast<int>(line.at(activePos + 4)) - 48;
                 envBypassed = !active;
                 break;
             }

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
@@ -210,5 +210,7 @@ private:
     std::vector<std::shared_ptr<PluginInstance>> getEarInputPluginsWithTrackMapping(int trackMapping, ReaperAPI const& api);
     TrackEnvelope* getEnvelopeFor(std::shared_ptr<admplug::PluginSuite> pluginSuite, PluginInstance * pluginInst, AdmParameter admParameter, ReaperAPI const & api);
     std::optional<double> getValueFor(std::shared_ptr<admplug::PluginSuite> pluginSuite, PluginInstance * pluginInst, AdmParameter admParameter, ReaperAPI const & api);
-
+    //TODO IAL
+    bool getEnvelopeBypassed(TrackEnvelope* env, ReaperAPI const& api);
+    //TODO IAL
 };

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
@@ -210,7 +210,5 @@ private:
     std::vector<std::shared_ptr<PluginInstance>> getEarInputPluginsWithTrackMapping(int trackMapping, ReaperAPI const& api);
     TrackEnvelope* getEnvelopeFor(std::shared_ptr<admplug::PluginSuite> pluginSuite, PluginInstance * pluginInst, AdmParameter admParameter, ReaperAPI const & api);
     std::optional<double> getValueFor(std::shared_ptr<admplug::PluginSuite> pluginSuite, PluginInstance * pluginInst, AdmParameter admParameter, ReaperAPI const & api);
-    //TODO IAL
     bool getEnvelopeBypassed(TrackEnvelope* env, ReaperAPI const& api);
-    //TODO IAL
 };

--- a/reaper-adm-extension/src/reaper_adm/exportaction_parameterprocessing.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_parameterprocessing.cpp
@@ -466,21 +466,23 @@ std::optional<std::vector<std::shared_ptr<adm::AudioBlockFormatObjects>>> Cumula
     std::vector<std::shared_ptr<adm::AudioBlockFormatObjects>> blocks;
 
     auto times = getSortedPointTimes();
-    double lastEndTime = 0.0;
+    auto lastEndTime = toNs(0.0);
 
     auto audioObjectDuration = regionEnd - regionStart;
 
     for(auto timeIt = times.begin(); timeIt != times.end(); timeIt++) {
 
+        const auto timeNs = toNs(*timeIt);
+        
         // Use front or back of parameter values vectors
         bool processBack = (*timeIt == 0.0); // For starting block, no point doing front and back - front would be ineffective.
 
         while(true) {
 
             std::shared_ptr<adm::AudioBlockFormatObjects> block;
-
-            auto rtime = toNs(lastEndTime) - regionStart;
-            auto duration = toNs(*timeIt - lastEndTime);
+   
+            auto rtime = lastEndTime - regionStart;
+            auto duration = timeNs - lastEndTime;
             auto endTime = rtime + duration;
 
             if(rtime < audioObjectDuration && endTime >= std::chrono::nanoseconds::zero()) {
@@ -551,7 +553,7 @@ std::optional<std::vector<std::shared_ptr<adm::AudioBlockFormatObjects>>> Cumula
                 blocks.push_back(block);
             }
 
-            lastEndTime = *timeIt;
+            lastEndTime = timeNs;
 
             // If we have already created an additional point or we don't need to create an additional point anyway, quit.
             if(processBack || !multipleValuesForSingleParameterAtTime(*timeIt)) break;


### PR DESCRIPTION
… but the search for the element's position requires the programme container UI object, which might not be alive when the plugin window is closed. If this happens, search through the programme store elements and remove if ID is found.

Probably fixes #28