### PR TITLE
Reset rebuildSceneStore flag to avoid rebuilding in every audio callback

### DIFF
--- a/ear-production-suite/lib/src/scene_backend.cpp
+++ b/ear-production-suite/lib/src/scene_backend.cpp
@@ -30,6 +30,7 @@ SceneBackend::~SceneBackend() { metadataSender_.asyncStop(); }
 communication::MessageBuffer SceneBackend::getMessage() {
   std::lock_guard<std::mutex> lock(storeMutex_);
   if (rebuildSceneStore_) {
+    rebuildSceneStore_ = false;
     updateSceneStore();
   }
   communication::MessageBuffer buffer =


### PR DESCRIPTION
If this doesn't fix the actual issue, it will at least fix a crash that happened every time i opened a project with monitoring plugins (GUI closed) but without scene, and then added the scene.