### PR TITLE
#25 language pack crashes

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/menu.cpp
+++ b/reaper-adm-extension/src/reaper_adm/menu.cpp
@@ -218,6 +218,10 @@ void RawMenu::insert(std::unique_ptr<MenuItem> item, std::shared_ptr<MenuInserte
     items.emplace_back(std::move(item), inserter);
 }
 
+bool RawMenu::checkHardcodedPosition(std::string itemText)
+{
+    return findPositionOfItemWithText(hMenu, itemText) == MenuTextToPostion.at(itemText);
+};
 
 SubMenu::SubMenu(std::string menuText) :
     text{menuText.begin(), menuText.end()},
@@ -378,3 +382,5 @@ int BeforeNamedItem::getIndex(HMENU menu) const
     index = std::max<int>(0, index);
     return index;
 }
+
+

--- a/reaper-adm-extension/src/reaper_adm/menu.cpp
+++ b/reaper-adm-extension/src/reaper_adm/menu.cpp
@@ -61,6 +61,13 @@ namespace {
         return nullptr;
     }
 
+    HMENU findHmenuOfItemWithPosition(HMENU menu, int itemPosition) {
+        auto itemCount = GetMenuItemCount(menu);
+        if (itemPosition < (itemCount - 1)) {
+            return GetSubMenu(menu, itemPosition);
+        }
+        return nullptr;
+    }
 }
 
 Insertable::Insertable(std::shared_ptr<MenuItem> item, std::shared_ptr<MenuInserter> inserter) :
@@ -189,6 +196,13 @@ std::shared_ptr<RawMenu> RawMenu::getMenuByText(std::string menuText)
 {
     auto hmenu = findHmenuOfItemWithText(hMenu, menuText);
     if(hmenu == nullptr) return nullptr;
+    return std::make_shared<RawMenu>(hmenu);
+}
+
+std::shared_ptr<RawMenu> RawMenu::getMenuByPosition(int menuPosition)
+{
+    auto hmenu = findHmenuOfItemWithPosition(hMenu, menuPosition);
+    if (hmenu == nullptr) return nullptr;
     return std::make_shared<RawMenu>(hmenu);
 }
 

--- a/reaper-adm-extension/src/reaper_adm/menu.cpp
+++ b/reaper-adm-extension/src/reaper_adm/menu.cpp
@@ -221,7 +221,7 @@ void RawMenu::insert(std::unique_ptr<MenuItem> item, std::shared_ptr<MenuInserte
 bool RawMenu::checkHardcodedPosition(std::string itemText)
 {
     return findPositionOfItemWithText(hMenu, itemText) == MenuTextToPostion.at(itemText);
-};
+}
 
 SubMenu::SubMenu(std::string menuText) :
     text{menuText.begin(), menuText.end()},

--- a/reaper-adm-extension/src/reaper_adm/menu.h
+++ b/reaper-adm-extension/src/reaper_adm/menu.h
@@ -96,7 +96,6 @@ public:
     void update(std::string menuId, HMENU menu) override;
     void insert(std::unique_ptr<MenuItem> item, std::shared_ptr<MenuInserter> inserter) override;
     std::shared_ptr<admplug::RawMenu> getMenuByText(std::string menuText);
-    std::shared_ptr<admplug::RawMenu> getMenuByText(std::wstring menuText);
     std::shared_ptr<admplug::RawMenu> getMenuByPosition(int menuPosition);
     bool checkHardcodedPosition(std::string menuText);
     void init();
@@ -136,23 +135,6 @@ public:
     int getIndex(HMENU) const override;
 private:
     std::string itemName;
-
-};
-
-class AfterNamedItemW : public MenuInserter {
-public:
-    AfterNamedItemW(std::wstring itemName);
-    int getIndex(HMENU) const override;
-private:
-    std::wstring itemName;
-};
-
-class BeforeNamedItemW : public MenuInserter {
-public:
-    BeforeNamedItemW(std::wstring itemName);
-    int getIndex(HMENU) const override;
-private:
-    std::wstring itemName;
 
 };
 

--- a/reaper-adm-extension/src/reaper_adm/menu.h
+++ b/reaper-adm-extension/src/reaper_adm/menu.h
@@ -96,6 +96,7 @@ public:
     void update(std::string menuId, HMENU menu) override;
     void insert(std::unique_ptr<MenuItem> item, std::shared_ptr<MenuInserter> inserter) override;
     std::shared_ptr<admplug::RawMenu> getMenuByText(std::string menuText);
+    std::shared_ptr<admplug::RawMenu> getMenuByPosition(int menuPosition);
     void init();
 private:
     HMENU hMenu;

--- a/reaper-adm-extension/src/reaper_adm/menu.h
+++ b/reaper-adm-extension/src/reaper_adm/menu.h
@@ -96,6 +96,7 @@ public:
     void update(std::string menuId, HMENU menu) override;
     void insert(std::unique_ptr<MenuItem> item, std::shared_ptr<MenuInserter> inserter) override;
     std::shared_ptr<admplug::RawMenu> getMenuByText(std::string menuText);
+    std::shared_ptr<admplug::RawMenu> getMenuByText(std::wstring menuText);
     std::shared_ptr<admplug::RawMenu> getMenuByPosition(int menuPosition);
     bool checkHardcodedPosition(std::string menuText);
     void init();
@@ -135,6 +136,23 @@ public:
     int getIndex(HMENU) const override;
 private:
     std::string itemName;
+
+};
+
+class AfterNamedItemW : public MenuInserter {
+public:
+    AfterNamedItemW(std::wstring itemName);
+    int getIndex(HMENU) const override;
+private:
+    std::wstring itemName;
+};
+
+class BeforeNamedItemW : public MenuInserter {
+public:
+    BeforeNamedItemW(std::wstring itemName);
+    int getIndex(HMENU) const override;
+private:
+    std::wstring itemName;
 
 };
 

--- a/reaper-adm-extension/src/reaper_adm/menu.h
+++ b/reaper-adm-extension/src/reaper_adm/menu.h
@@ -97,6 +97,7 @@ public:
     void insert(std::unique_ptr<MenuItem> item, std::shared_ptr<MenuInserter> inserter) override;
     std::shared_ptr<admplug::RawMenu> getMenuByText(std::string menuText);
     std::shared_ptr<admplug::RawMenu> getMenuByPosition(int menuPosition);
+    bool checkHardcodedPosition(std::string menuText);
     void init();
 private:
     HMENU hMenu;
@@ -165,5 +166,11 @@ private:
     HMENU mainMenu;
 };
 
+static const std::map<const std::string, const int> MenuTextToPostion = {
+    {"File", 0},
+    {"Insert", 3},
+    {"Project templates", 8},
+    {"Empty item", 2}
+};
 
 }

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -50,13 +50,6 @@ struct CrtBreakAllocSetter {
 CrtBreakAllocSetter g_crtBreakAllocSetter;
 */
 
-static const std::map<const std::string, const int> MenuTextToPostion = {
-    {"File", 0},
-    {"Insert", 3},
-    {"Project templates", 8},
-    {"Empty item", 3}
-};
-
 
 extern "C" {
   int REAPER_PLUGIN_DLL_EXPORT REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t *rec)
@@ -185,8 +178,11 @@ extern "C" {
     auto reaperFileMenu = reaperMainMenu->getMenuByText("File");
     if (reaperFileMenu) {
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
-    }
-    else {
+
+        // Warning if the hard-coded fallback menu positions don't match anymore
+        if (!reaperMainMenu->checkHardcodedPosition("File")) api->ShowMessageBox("Positions of File menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperFileMenu->checkHardcodedPosition("Project templates")) api->ShowMessageBox("Positions of Project templates menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+    } else {
         reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
     }
@@ -234,10 +230,13 @@ extern "C" {
     auto reaperInsertMenu = reaperMainMenu->getMenuByText("Insert");
     if (reaperInsertMenu) {
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
-    }
-    else {
+
+        // Warning if the hard-coded fallback menu positions don't match anymore
+        if (!reaperMainMenu->checkHardcodedPosition("Insert")) api->ShowMessageBox("Positions of Insert menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperInsertMenu->checkHardcodedPosition("Empty item")) api->ShowMessageBox("Positions of Empty item menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+    } else {
         reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
-        reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item")));
+        reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item") + 1));
     }
     assert(reaperInsertMenu);
     reaperInsertMenu->init();

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -180,8 +180,8 @@ extern "C" {
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
 
         // Warning if the hard-coded fallback menu positions don't match anymore
-        if (!reaperMainMenu->checkHardcodedPosition("File")) api->ShowMessageBox("Positions of File menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
-        if (!reaperFileMenu->checkHardcodedPosition("Project templates")) api->ShowMessageBox("Positions of Project templates menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperMainMenu->checkHardcodedPosition("File")) api->ShowMessageBox("Position of File menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperFileMenu->checkHardcodedPosition("Project templates")) api->ShowMessageBox("Position of Project templates menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
     } else {
         reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
@@ -232,8 +232,8 @@ extern "C" {
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
 
         // Warning if the hard-coded fallback menu positions don't match anymore
-        if (!reaperMainMenu->checkHardcodedPosition("Insert")) api->ShowMessageBox("Positions of Insert menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
-        if (!reaperInsertMenu->checkHardcodedPosition("Empty item")) api->ShowMessageBox("Positions of Empty item menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperMainMenu->checkHardcodedPosition("Insert")) api->ShowMessageBox("Position of Insert menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperInsertMenu->checkHardcodedPosition("Empty item")) api->ShowMessageBox("Position of Empty item menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
     } else {
         reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item") + 1));

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -67,13 +67,10 @@ extern "C" {
     };
 
     try {
-        reaper = std::make_unique<ReaperHost>(hInstance, rec);
-    } catch (FuncResolutionException const& e) {
-        nonBlockingMessage(e.what());
-        reaper = std::make_unique<ReaperHost>(hInstance, rec, false);
+      reaper = std::make_unique<ReaperHost>(hInstance, rec);
     } catch (ReaperAPIException const& e) {
-        nonBlockingMessage(e.what());
-        return 0;
+      nonBlockingMessage(e.what());
+      return 0;
     }
 
     if(!rec) {
@@ -180,8 +177,8 @@ extern "C" {
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
 
         // Warning if the hard-coded fallback menu positions don't match anymore
-        if (!reaperMainMenu->checkHardcodedPosition("File")) api->ShowMessageBox("Position of File menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
-        if (!reaperFileMenu->checkHardcodedPosition("Project templates")) api->ShowMessageBox("Position of Project templates menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperMainMenu->checkHardcodedPosition("File")) nonBlockingMessage("Position of File menu does not match hard-coded fallback index.");
+        if (!reaperFileMenu->checkHardcodedPosition("Project templates")) nonBlockingMessage("Position of Project templates menu does not match hard-coded fallback index.");
     } else {
         reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
@@ -232,8 +229,8 @@ extern "C" {
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
 
         // Warning if the hard-coded fallback menu positions don't match anymore
-        if (!reaperMainMenu->checkHardcodedPosition("Insert")) api->ShowMessageBox("Position of Insert menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
-        if (!reaperInsertMenu->checkHardcodedPosition("Empty item")) api->ShowMessageBox("Position of Empty item menu does not match hard-coded fallback index.", "ADM Extension Error", MB_ICONEXCLAMATION);
+        if (!reaperMainMenu->checkHardcodedPosition("Insert")) nonBlockingMessage("Position of Insert menu does not match hard-coded fallback index.");
+        if (!reaperInsertMenu->checkHardcodedPosition("Empty item")) nonBlockingMessage("Position of Empty item menu does not match hard-coded fallback index.");
     } else {
         reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item") + 1));

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -65,13 +65,6 @@ extern "C" {
 #endif
     };
 
-    auto uft8ToUtf16 = [](std::string utf8) {
-        const int wchars_num = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), utf8.length(), NULL, 0);
-        std::wstring utf16(wchars_num, ' ');
-        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), utf8.length(), utf16.data(), wchars_num);
-        return utf16;
-    };
-
     try {
         reaper = std::make_unique<ReaperHost>(hInstance, rec);
     } catch (FuncResolutionException const& e) {
@@ -183,9 +176,9 @@ extern "C" {
 
     std::shared_ptr<admplug::RawMenu> reaperFileMenu;
     if (std::stof(api->GetAppVersion()) >= 6.11f) {
-        reaperFileMenu = reaperMainMenu->getMenuByText(uft8ToUtf16(api->LocalizeString("&File", "common", 0))); 
+        reaperFileMenu = reaperMainMenu->getMenuByText(api->LocalizeString("&File", "common", 0)); 
         if (reaperFileMenu) {
-            reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItemW>(uft8ToUtf16(api->LocalizeString("Project &templates", "MENU_102", 0))));
+            reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>(api->LocalizeString("Project &templates", "MENU_102", 0)));
         }
     } else {
         reaperFileMenu = reaperMainMenu->getMenuByText("File");
@@ -244,9 +237,9 @@ extern "C" {
 
     std::shared_ptr<admplug::RawMenu> reaperInsertMenu;
     if (std::stof(api->GetAppVersion()) >= 6.11f) {
-        reaperInsertMenu = reaperMainMenu->getMenuByText(uft8ToUtf16(api->LocalizeString("&Insert", "common", 0)));
+        reaperInsertMenu = reaperMainMenu->getMenuByText(api->LocalizeString("&Insert", "common", 0));
         if (reaperInsertMenu) {
-            reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItemW>(uft8ToUtf16(api->LocalizeString("Empty item", "MENU_102", 0))));
+            reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>(api->LocalizeString("Empty item", "MENU_102", 0)));
         }
     } else {
         reaperInsertMenu = reaperMainMenu->getMenuByText("Insert");

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -53,32 +53,32 @@ CrtBreakAllocSetter g_crtBreakAllocSetter;
 extern "C" {
   int REAPER_PLUGIN_DLL_EXPORT REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t *rec)
   {
-      using namespace admplug;
-      std::unique_ptr<ReaperHost> reaper;
+    using namespace admplug;
+    std::unique_ptr<ReaperHost> reaper;
 
-      auto nonBlockingMessage = [rec](const char* text) {
+    auto nonBlockingMessage = [rec](const char* text) {
 #ifdef WIN32
-          // Windows version of Reaper locks up if you try show a message box during splash
-          winhelpers::NonBlockingMessageBox(text, "ADM Extension Error", MB_ICONEXCLAMATION);
+        // Windows version of Reaper locks up if you try show a message box during splash
+        winhelpers::NonBlockingMessageBox(text, "ADM Extension Error", MB_ICONEXCLAMATION);
 #else
-          MessageBox(rec->hwnd_main, text, "ADM Extension Error", MB_OK);
+        MessageBox(rec->hwnd_main, text, "ADM Extension Error", MB_OK);
 #endif
-      };
+    };
 
-      try {
-          reaper = std::make_unique<ReaperHost>(hInstance, rec);
-      } catch (FuncResolutionException const& e) {
-          nonBlockingMessage(e.what());
-          reaper = std::make_unique<ReaperHost>(hInstance, rec, false);
-      } catch (ReaperAPIException const& e) {
-          nonBlockingMessage(e.what());
-          return 0;
-      }
+    try {
+        reaper = std::make_unique<ReaperHost>(hInstance, rec);
+    } catch (FuncResolutionException const& e) {
+        nonBlockingMessage(e.what());
+        reaper = std::make_unique<ReaperHost>(hInstance, rec, false);
+    } catch (ReaperAPIException const& e) {
+        nonBlockingMessage(e.what());
+        return 0;
+    }
 
-      if (!rec) {
-          // unload plugin
-          return 0;
-      }
+    if (!rec) {
+        // unload plugin
+        return 0;
+    }
 
     auto reaperMainMenu = std::dynamic_pointer_cast<RawMenu>(reaper->getMenu(MenuID::MAIN_MENU));
     assert(reaperMainMenu);

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -176,9 +176,9 @@ extern "C" {
     if (reaperFileMenu) {
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
 
-        // Warning if the hard-coded fallback menu positions don't match anymore
-        if (!reaperMainMenu->checkHardcodedPosition("File")) nonBlockingMessage("Position of File menu does not match hard-coded fallback index.");
-        if (!reaperFileMenu->checkHardcodedPosition("Project templates")) nonBlockingMessage("Position of Project templates menu does not match hard-coded fallback index.");
+        // Assertions to check that the hard-coded fallback menu positions still match
+        assert(reaperMainMenu->checkHardcodedPosition("File"));
+        assert(reaperFileMenu->checkHardcodedPosition("Project templates"));
     } else {
         reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
@@ -228,9 +228,9 @@ extern "C" {
     if (reaperInsertMenu) {
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
 
-        // Warning if the hard-coded fallback menu positions don't match anymore
-        if (!reaperMainMenu->checkHardcodedPosition("Insert")) nonBlockingMessage("Position of Insert menu does not match hard-coded fallback index.");
-        if (!reaperInsertMenu->checkHardcodedPosition("Empty item")) nonBlockingMessage("Position of Empty item menu does not match hard-coded fallback index.");
+        // Assertions to check that the hard-coded fallback menu positions still match
+        assert(reaperMainMenu->checkHardcodedPosition("Insert"));
+        assert(reaperInsertMenu->checkHardcodedPosition("Empty item"));
     } else {
         reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item") + 1));

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -50,6 +50,14 @@ struct CrtBreakAllocSetter {
 CrtBreakAllocSetter g_crtBreakAllocSetter;
 */
 
+static const std::map<const std::string, const int> MenuTextToPostion = {
+    {"File", 0},
+    {"Insert", 3},
+    {"Project templates", 8},
+    {"Empty item", 3}
+};
+
+
 extern "C" {
   int REAPER_PLUGIN_DLL_EXPORT REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t *rec)
   {
@@ -174,9 +182,9 @@ extern "C" {
         admFileMenu->insert(std::move(explodeItem), std::make_shared<EndOffset>(0));
     }
 
-    auto reaperFileMenu = reaperMainMenu->getMenuByText("File");
+    auto reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
     assert(reaperFileMenu);
-    reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
+    reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
     reaperFileMenu->init();
 
     // Insert menu
@@ -217,9 +225,9 @@ extern "C" {
         admInsertMenu->insert(std::move(explodeItem), std::make_shared<EndOffset>(0));
     }
 
-    auto reaperInsertMenu = reaperMainMenu->getMenuByText("Insert");
+    auto reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
     assert(reaperInsertMenu);
-    reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
+    reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item")));
     reaperInsertMenu->init();
 
     return 1;

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -65,6 +65,13 @@ extern "C" {
 #endif
     };
 
+    auto uft8ToUtf16 = [](std::string utf8) {
+        const int wchars_num = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), utf8.length(), NULL, 0);
+        std::wstring utf16(wchars_num, ' ');
+        MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), utf8.length(), utf16.data(), wchars_num);
+        return utf16;
+    };
+
     try {
         reaper = std::make_unique<ReaperHost>(hInstance, rec);
     } catch (FuncResolutionException const& e) {
@@ -174,14 +181,23 @@ extern "C" {
         admFileMenu->insert(std::move(explodeItem), std::make_shared<EndOffset>(0));
     }
 
-    auto reaperFileMenu = reaperMainMenu->getMenuByText("File");
-    if (reaperFileMenu) {
-        reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
-
-        // Assertions to check that the hard-coded fallback menu positions still match
-        assert(reaperMainMenu->checkHardcodedPosition("File"));
-        assert(reaperFileMenu->checkHardcodedPosition("Project templates"));
+    std::shared_ptr<admplug::RawMenu> reaperFileMenu;
+    if (std::stof(api->GetAppVersion()) >= 6.11f) {
+        reaperFileMenu = reaperMainMenu->getMenuByText(uft8ToUtf16(api->LocalizeString("&File", "common", 0))); 
+        if (reaperFileMenu) {
+            reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItemW>(uft8ToUtf16(api->LocalizeString("Project &templates", "MENU_102", 0))));
+        }
     } else {
+        reaperFileMenu = reaperMainMenu->getMenuByText("File");
+        if (reaperFileMenu) {
+            reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
+
+            // Assertions to check that the hard-coded fallback menu positions still match
+            assert(reaperMainMenu->checkHardcodedPosition("File"));
+            assert(reaperFileMenu->checkHardcodedPosition("Project templates"));
+        }
+    }
+    if (!reaperFileMenu) {
         reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
         reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
     }
@@ -226,14 +242,23 @@ extern "C" {
         admInsertMenu->insert(std::move(explodeItem), std::make_shared<EndOffset>(0));
     }
 
-    auto reaperInsertMenu = reaperMainMenu->getMenuByText("Insert");
-    if (reaperInsertMenu) {
-        reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
-
-        // Assertions to check that the hard-coded fallback menu positions still match
-        assert(reaperMainMenu->checkHardcodedPosition("Insert"));
-        assert(reaperInsertMenu->checkHardcodedPosition("Empty item"));
+    std::shared_ptr<admplug::RawMenu> reaperInsertMenu;
+    if (std::stof(api->GetAppVersion()) >= 6.11f) {
+        reaperInsertMenu = reaperMainMenu->getMenuByText(uft8ToUtf16(api->LocalizeString("&Insert", "common", 0)));
+        if (reaperInsertMenu) {
+            reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItemW>(uft8ToUtf16(api->LocalizeString("Empty item", "MENU_102", 0))));
+        }
     } else {
+        reaperInsertMenu = reaperMainMenu->getMenuByText("Insert");
+        if (reaperInsertMenu) {
+            reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
+
+            // Assertions to check that the hard-coded fallback menu positions still match
+            assert(reaperMainMenu->checkHardcodedPosition("Insert"));
+            assert(reaperInsertMenu->checkHardcodedPosition("Empty item"));
+        }
+    }
+    if (!reaperInsertMenu) {
         reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
         reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item") + 1));
     }

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -182,9 +182,15 @@ extern "C" {
         admFileMenu->insert(std::move(explodeItem), std::make_shared<EndOffset>(0));
     }
 
-    auto reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
+    auto reaperFileMenu = reaperMainMenu->getMenuByText("File");
+    if (reaperFileMenu) {
+        reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<BeforeNamedItem>("Project templates"));
+    }
+    else {
+        reaperFileMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("File"));
+        reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
+    }
     assert(reaperFileMenu);
-    reaperFileMenu->insert(std::move(admFileMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Project templates")));
     reaperFileMenu->init();
 
     // Insert menu
@@ -225,9 +231,15 @@ extern "C" {
         admInsertMenu->insert(std::move(explodeItem), std::make_shared<EndOffset>(0));
     }
 
-    auto reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
+    auto reaperInsertMenu = reaperMainMenu->getMenuByText("Insert");
+    if (reaperInsertMenu) {
+        reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<AfterNamedItem>("Empty item"));
+    }
+    else {
+        reaperInsertMenu = reaperMainMenu->getMenuByPosition(MenuTextToPostion.at("Insert"));
+        reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item")));
+    }
     assert(reaperInsertMenu);
-    reaperInsertMenu->insert(std::move(admInsertMenu), std::make_shared<StartOffset>(MenuTextToPostion.at("Empty item")));
     reaperInsertMenu->init();
 
     return 1;

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -50,33 +50,35 @@ struct CrtBreakAllocSetter {
 CrtBreakAllocSetter g_crtBreakAllocSetter;
 */
 
-
 extern "C" {
   int REAPER_PLUGIN_DLL_EXPORT REAPER_PLUGIN_ENTRYPOINT(REAPER_PLUGIN_HINSTANCE hInstance, reaper_plugin_info_t *rec)
   {
-    using namespace admplug;
-    std::unique_ptr<ReaperHost> reaper;
+      using namespace admplug;
+      std::unique_ptr<ReaperHost> reaper;
 
-    auto nonBlockingMessage = [rec](const char* text) {
+      auto nonBlockingMessage = [rec](const char* text) {
 #ifdef WIN32
-        // Windows version of Reaper locks up if you try show a message box during splash
-        winhelpers::NonBlockingMessageBox(text, "ADM Extension Error", MB_ICONEXCLAMATION);
+          // Windows version of Reaper locks up if you try show a message box during splash
+          winhelpers::NonBlockingMessageBox(text, "ADM Extension Error", MB_ICONEXCLAMATION);
 #else
-        MessageBox(rec->hwnd_main, text, "ADM Extension Error", MB_OK);
+          MessageBox(rec->hwnd_main, text, "ADM Extension Error", MB_OK);
 #endif
-    };
+      };
 
-    try {
-      reaper = std::make_unique<ReaperHost>(hInstance, rec);
-    } catch (ReaperAPIException const& e) {
-      nonBlockingMessage(e.what());
-      return 0;
-    }
+      try {
+          reaper = std::make_unique<ReaperHost>(hInstance, rec);
+      } catch (FuncResolutionException const& e) {
+          nonBlockingMessage(e.what());
+          reaper = std::make_unique<ReaperHost>(hInstance, rec, false);
+      } catch (ReaperAPIException const& e) {
+          nonBlockingMessage(e.what());
+          return 0;
+      }
 
-    if(!rec) {
-        // unload plugin
-        return 0;
-    }
+      if (!rec) {
+          // unload plugin
+          return 0;
+      }
 
     auto reaperMainMenu = std::dynamic_pointer_cast<RawMenu>(reaper->getMenu(MenuID::MAIN_MENU));
     assert(reaperMainMenu);

--- a/reaper-adm-extension/src/reaper_adm/reaperapi.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperapi.h
@@ -153,6 +153,7 @@ class ReaperAPI {
     virtual MediaItem* GetTrackMediaItem(MediaTrack* tr, int itemidx) const = 0;
     virtual double GetSetProjectInfo(ReaProject * project, const char* desc, double value, bool is_set) const = 0;
     virtual const char* GetAppVersion() const = 0;
+    virtual const char* LocalizeString(const char* src_string, const char* section, int flagsOptional) const = 0;
 
     static constexpr int RENDER_ITEMS_AS_NEW_TAKE_ID = 41999;
     static constexpr int CROP_TO_ACTIVE_TAKE_IN_ITEMS = 40131;

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
@@ -493,6 +493,11 @@ const char* admplug::ReaperAPIImpl::GetAppVersion() const
     return ::GetAppVersion();
 }
 
+const char* admplug::ReaperAPIImpl::LocalizeString(const char* src_string, const char* section, int flagsOptional) const
+{
+    return ::LocalizeString(src_string, section, flagsOptional);
+}
+
 void ReaperAPIImpl::UpdateArrangeForAutomation() const {
   // UpdateArrange() does not force draw of automation. Flipping master track visibility does.
   std::bitset<4> mstTrkSetting(GetMasterTrackVisibility());

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.h
@@ -111,6 +111,7 @@ public:
     MediaItem* GetTrackMediaItem(MediaTrack* tr, int itemidx) const override;
     double GetSetProjectInfo(ReaProject* project, const char* desc, double value, bool is_set) const override;
     const char* GetAppVersion() const override;
+    const char* LocalizeString(const char* src_string, const char* section, int flagsOptional) const override;
 
     //Custom Funcs
     void UpdateArrangeForAutomation() const override;

--- a/reaper-adm-extension/test/reaper_adm/mocks/reaperapi.h
+++ b/reaper-adm-extension/test/reaper_adm/mocks/reaperapi.h
@@ -185,6 +185,7 @@ class MockReaperAPI : public ReaperAPI {
   MOCK_CONST_METHOD2(GetTrackMediaItem, MediaItem*(MediaTrack* tr, int itemidx));
   MOCK_CONST_METHOD4(GetSetProjectInfo, double(ReaProject* project, const char* desc, double value, bool is_set));
   MOCK_CONST_METHOD0(GetAppVersion, const char*());
+  MOCK_CONST_METHOD3(LocalizeString, const char*(const char* src_string, const char* section, int flagsOptional));
 
   // Custom funcs
   MOCK_CONST_METHOD0(UpdateArrangeForAutomation,


### PR DESCRIPTION
As suggested by @firthm01 to fix #25, the extension first trys to insert the menus by searching for the corresponding labels. If this fails it will fall back to the hard-coded fallback positions.

After sucessfully inserting the menus by using the labels, the fallback positions are checked for correctness. However, this could also fail if other extensions are manipulating the reaper menus. So instead of causing an exception, a warning will be displayed if this check fails.