### PR TITLE
Mark plugin state as dirty when NonAutomatableParameter is changed…

### DIFF
--- a/ear-production-suite/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -188,12 +188,16 @@ void DirectSpeakersJuceFrontendConnector::parameterValueChanged(
   switch (parameterIndex) {
     case 0:
       notifyParameterChanged(ParameterId::ROUTING, p_->getRouting()->get());
-      setRouting(p_->getRouting()->get());
+      updater_.callOnMessageThread([this]() {
+        setRouting(p_->getRouting()->get());
+      });
       break;
     case 1:
       notifyParameterChanged(ParameterId::SPEAKER_SETUP_INDEX,
                              p_->getSpeakerSetupIndex()->get());
-      setSpeakerSetup(p_->getSpeakerSetupIndex()->get());
+      updater_.callOnMessageThread([this]() {
+        setSpeakerSetup(p_->getSpeakerSetupIndex()->get());
+      });
       break;
   }
 }

--- a/ear-production-suite/plugins/direct_speakers/src/direct_speakers_plugin_processor.hpp
+++ b/ear-production-suite/plugins/direct_speakers/src/direct_speakers_plugin_processor.hpp
@@ -51,6 +51,10 @@ class DirectSpeakersAudioProcessor : public AudioProcessor {
 
   AudioParameterInt* getRouting() { return routing_; }
   AudioParameterInt* getSpeakerSetupIndex() { return speakerSetupIndex_; }
+  
+  AudioProcessorParameter* getBypassParameter() {
+    return bypass_;
+  }
 
   std::weak_ptr<ear::plugin::LevelMeterCalculator> getLevelMeter() {
     return levelMeter_;
@@ -65,6 +69,7 @@ class DirectSpeakersAudioProcessor : public AudioProcessor {
 
   AudioParameterInt* routing_;
   AudioParameterInt* speakerSetupIndex_;
+  AudioParameterBool* bypass_;
 
   std::unique_ptr<ear::plugin::ui::DirectSpeakersJuceFrontendConnector>
       connector_;

--- a/ear-production-suite/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite/plugins/object/src/object_plugin_processor.cpp
@@ -30,6 +30,10 @@ ObjectsAudioProcessor::ObjectsAudioProcessor()
   addParameter(range_ = new AudioParameterFloat("range", "Range", 0.f, 180.f, 45.f));
   /* clang-format on */
 
+  static_cast<ui::NonAutomatedParameter<AudioParameterInt>*>(routing_)->markPluginStateAsDirty = [this]() {
+    gain_->setValueNotifyingHost(gain_->get());
+  };
+
   connector_ = std::make_unique<ui::ObjectsJuceFrontendConnector>(this);
   backend_ = std::make_unique<ObjectBackend>(connector_.get());
 
@@ -104,8 +108,8 @@ bool ObjectsAudioProcessor::isBusesLayoutSupported(
 
 void ObjectsAudioProcessor::processBlock(AudioBuffer<float>& buffer,
                                          MidiBuffer& midiMessages) {
-  levelMeter_->process(buffer);
-  backend_->triggerMetadataSend();
+    levelMeter_->process(buffer);
+    backend_->triggerMetadataSend();
 }
 
 bool ObjectsAudioProcessor::hasEditor() const { return true; }

--- a/ear-production-suite/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite/plugins/object/src/object_plugin_processor.cpp
@@ -28,10 +28,11 @@ ObjectsAudioProcessor::ObjectsAudioProcessor()
   addParameter(divergence_ = new AudioParameterBool("divergence", "Divergence", false));
   addParameter(factor_ = new AudioParameterFloat("factor", "Factor", 0.f, 1.f, 0.f));
   addParameter(range_ = new AudioParameterFloat("range", "Range", 0.f, 180.f, 45.f));
+  addParameter(bypass_ = new AudioParameterBool("byps", "Bypass", false));
   /* clang-format on */
 
   static_cast<ui::NonAutomatedParameter<AudioParameterInt>*>(routing_)->markPluginStateAsDirty = [this]() {
-    gain_->setValueNotifyingHost(gain_->get());
+    bypass_->setValueNotifyingHost(bypass_->get());
   };
 
   connector_ = std::make_unique<ui::ObjectsJuceFrontendConnector>(this);
@@ -108,8 +109,10 @@ bool ObjectsAudioProcessor::isBusesLayoutSupported(
 
 void ObjectsAudioProcessor::processBlock(AudioBuffer<float>& buffer,
                                          MidiBuffer& midiMessages) {
+  if(! bypass_->get()) {
     levelMeter_->process(buffer);
     backend_->triggerMetadataSend();
+  }
 }
 
 bool ObjectsAudioProcessor::hasEditor() const { return true; }

--- a/ear-production-suite/plugins/object/src/object_plugin_processor.hpp
+++ b/ear-production-suite/plugins/object/src/object_plugin_processor.hpp
@@ -63,6 +63,10 @@ class ObjectsAudioProcessor : public AudioProcessor {
   AudioParameterFloat* getFactor() { return factor_; }
   AudioParameterFloat* getRange() { return range_; }
 
+  AudioProcessorParameter* getBypassParameter() {
+    return bypass_;
+  }
+
   std::weak_ptr<ear::plugin::LevelMeterCalculator> getLevelMeter() {
     return levelMeter_;
   };
@@ -88,6 +92,7 @@ class ObjectsAudioProcessor : public AudioProcessor {
   AudioParameterBool* divergence_;
   AudioParameterFloat* factor_;
   AudioParameterFloat* range_;
+  AudioParameterBool* bypass_;
 
   std::unique_ptr<ear::plugin::ui::ObjectsJuceFrontendConnector> connector_;
   std::unique_ptr<ear::plugin::ObjectBackend> backend_;

--- a/ear-production-suite/plugins/shared/components/non_automatable_parameter.hpp
+++ b/ear-production-suite/plugins/shared/components/non_automatable_parameter.hpp
@@ -26,6 +26,13 @@ class NonAutomatedParameter : public BaseParameter {
   using BaseParameter::BaseParameter;
 
   bool isAutomatable() const override { return false; }
+  
+  std::function<void()> markPluginStateAsDirty = [](){};
+  
+private:
+  void valueChanged(decltype(std::declval<BaseParameter>().get()) value) override {
+    markPluginStateAsDirty();
+  }
 };
 
 }  // namespace ui


### PR DESCRIPTION
… by re-setting one of the automated parameters. Add custom bypass parameter to DirectSpeakers to enable this.

Fixes #33