### PR TITLE
Avoid UI call from audio thread by moving update to message thread...

### DIFF
--- a/ear-production-suite/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -188,12 +188,16 @@ void DirectSpeakersJuceFrontendConnector::parameterValueChanged(
   switch (parameterIndex) {
     case 0:
       notifyParameterChanged(ParameterId::ROUTING, p_->getRouting()->get());
-      setRouting(p_->getRouting()->get());
+      updater_.callOnMessageThread([this]() {
+        setRouting(p_->getRouting()->get());
+      });
       break;
     case 1:
       notifyParameterChanged(ParameterId::SPEAKER_SETUP_INDEX,
                              p_->getSpeakerSetupIndex()->get());
-      setSpeakerSetup(p_->getSpeakerSetupIndex()->get());
+      updater_.callOnMessageThread([this]() {
+        setSpeakerSetup(p_->getSpeakerSetupIndex()->get());
+      });
       break;
   }
 }


### PR DESCRIPTION
…(this is triggered by a parameter update, which can come from the audio thread).
Found this while testing issue 33, same problem as in the previously solved objectVST issue.