### PR TITLE
Fix install path regression introduced by #50

### DIFF
--- a/ear-production-suite/plugins/direct_speakers/CMakeLists.txt
+++ b/ear-production-suite/plugins/direct_speakers/CMakeLists.txt
@@ -20,4 +20,4 @@ add_juce_vst3_plugin(direct_speakers
   
 target_link_libraries(direct_speakers_VST3 PRIVATE ear-plugin-base)
 
-install_juce_vst3_plugin(direct_speakers "${EAR_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")
+install_juce_vst3_plugin(direct_speakers "${EPS_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")

--- a/ear-production-suite/plugins/monitoring/CMakeLists.txt
+++ b/ear-production-suite/plugins/monitoring/CMakeLists.txt
@@ -20,7 +20,7 @@ function(add_monitoring_plugin SPEAKER_LAYOUT SPEAKER_LAYOUT_NAME PLUGIN_CODE_SU
     SPEAKER_LAYOUT_NAME="${SPEAKER_LAYOUT_NAME}"
     )
   target_link_libraries(ear_monitoring_${SPEAKER_LAYOUT}_VST3 PRIVATE ear-plugin-base)
-  install_juce_vst3_plugin(ear_monitoring_${SPEAKER_LAYOUT} "${EAR_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")
+  install_juce_vst3_plugin(ear_monitoring_${SPEAKER_LAYOUT} "${EPS_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")
 endfunction()
 
 

--- a/ear-production-suite/plugins/object/CMakeLists.txt
+++ b/ear-production-suite/plugins/object/CMakeLists.txt
@@ -21,4 +21,4 @@ add_juce_vst3_plugin(object
   
 target_include_directories(object_VST3 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(object_VST3 PRIVATE ear-plugin-base)
-install_juce_vst3_plugin(object "${EAR_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")
+install_juce_vst3_plugin(object "${EPS_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")

--- a/ear-production-suite/plugins/scene/CMakeLists.txt
+++ b/ear-production-suite/plugins/scene/CMakeLists.txt
@@ -26,6 +26,6 @@ add_juce_vst3_plugin(scene
   OUTPUT_NAME "EAR Scene")
   
 target_link_libraries(scene_VST3 PRIVATE ear-plugin-base)
-install_juce_vst3_plugin(scene "${EAR_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")
+install_juce_vst3_plugin(scene "${EPS_PLUGIN_INSTALL_PREFIX}VST3/ear-production-suite")
 
 

--- a/reaper_adm_stem_plugin/src/CMakeLists.txt
+++ b/reaper_adm_stem_plugin/src/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(adm_export_source_VST3
 target_compile_definitions(adm_export_source_VST3
     PUBLIC JUCE_DISABLE_ASSERTIONS)
 
-install_juce_vst3_plugin(adm_export_source "${EAR_PLUGIN_INSTALL_PREFIX}VST3")
+install_juce_vst3_plugin(adm_export_source "${EPS_PLUGIN_INSTALL_PREFIX}VST3")
 
 include(DeployVST3)
 


### PR DESCRIPTION
A typo in a cmake variable prevented default install locations from being correctly set for all plugins, this fixes that.