### PR TITLE
Fix #87 Scene appears to delete wrong item

### DIFF
--- a/ear-production-suite/plugins/scene/CMakeLists.txt
+++ b/ear-production-suite/plugins/scene/CMakeLists.txt
@@ -16,6 +16,9 @@ set(SOURCES_SCENE_MASTER
   src/backend_setup_timer.cpp
   src/scene_plugin_editor.cpp
   src/scene_plugin_processor.cpp
+  src/elements_container.cpp
+  src/element_view_list.cpp
+  src/element_view.cpp
 )
 
 add_juce_vst3_plugin(scene

--- a/ear-production-suite/plugins/scene/src/element_view.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view.cpp
@@ -16,9 +16,9 @@ ElementView::ElementView()
       Drawable::createFromImageData(binary_data::drag_handle_icon_svg,
                                     binary_data::drag_handle_icon_svgSize)));
   handleButton_->setColour(EarButton::highlightColourId,
-                            EarColours::Transparent);
+                           EarColours::Transparent);
   handleButton_->setColour(EarButton::backgroundColourId,
-                            EarColours::Transparent);
+                           EarColours::Transparent);
   handleButton_->setColour(EarButton::hoverColourId, EarColours::Transparent);
   addAndMakeVisible(handleButton_.get());
 
@@ -30,9 +30,9 @@ ElementView::ElementView()
       Drawable::createFromImageData(binary_data::delete_icon_red_svg,
                                     binary_data::delete_icon_red_svgSize)));
   removeButton_->setColour(EarButton::highlightColourId,
-                            EarColours::Transparent);
+                           EarColours::Transparent);
   removeButton_->setColour(EarButton::backgroundColourId,
-                            EarColours::Transparent);
+                           EarColours::Transparent);
   removeButton_->setColour(EarButton::hoverColourId, EarColours::Transparent);
 
   addAndMakeVisible(removeButton_.get());
@@ -58,34 +58,22 @@ void ElementView::mouseDown(const MouseEvent& event) {
     auto image = createComponentSnapshot(getLocalBounds());
     image.multiplyAllAlphas(Emphasis::medium);
     dragContainer->startDragging("element", this, image, true,
-                                  &dragStartOffset_);
+                                 &dragStartOffset_);
     setAlpha(Emphasis::disabled);
   }
 }
 
-void ElementView::mouseEnter(const MouseEvent& event) {
-  repaint();
-}
+void ElementView::mouseEnter(const MouseEvent& event) { repaint(); }
 
-void ElementView::mouseExit(const MouseEvent& event) {
-  repaint();
-}
+void ElementView::mouseExit(const MouseEvent& event) { repaint(); }
 
-void ElementView::mouseUp(const MouseEvent& event) {
-  setAlpha(Emphasis::full);
-}
+void ElementView::mouseUp(const MouseEvent& event) { setAlpha(Emphasis::full); }
 
-void ElementView::resized() {
-  setSize(getParentWidth(), 100);
-}
+void ElementView::resized() { setSize(getParentWidth(), 100); }
 
-EarButton* ElementView::getHandleButton() {
-  return handleButton_.get();
-}
+EarButton* ElementView::getHandleButton() { return handleButton_.get(); }
 
-EarButton* ElementView::getRemoveButton() {
-  return removeButton_.get();
-}
+EarButton* ElementView::getRemoveButton() { return removeButton_.get(); }
 
 }  // namespace ui
 }  // namespace plugin

--- a/ear-production-suite/plugins/scene/src/element_view.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view.cpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "element_view.hpp"
+
+#include "../../shared/components/look_and_feel/colours.hpp"
+#include "../../shared/components/look_and_feel/fonts.hpp"
+
+namespace ear {
+namespace plugin {
+namespace ui {
+
+ElementView::ElementView()
+    : handleButton_(std::make_unique<EarButton>()),
+      removeButton_(std::make_unique<EarButton>()) {
+  handleButton_->setOffStateIcon(std::unique_ptr<Drawable>(
+      Drawable::createFromImageData(binary_data::drag_handle_icon_svg,
+                                    binary_data::drag_handle_icon_svgSize)));
+  handleButton_->setColour(EarButton::highlightColourId,
+                            EarColours::Transparent);
+  handleButton_->setColour(EarButton::backgroundColourId,
+                            EarColours::Transparent);
+  handleButton_->setColour(EarButton::hoverColourId, EarColours::Transparent);
+  addAndMakeVisible(handleButton_.get());
+
+  removeButton_->setOffStateIcon(
+      std::unique_ptr<Drawable>(Drawable::createFromImageData(
+          binary_data::delete_icon_svg, binary_data::delete_icon_svgSize)),
+      Emphasis::medium);
+  removeButton_->setHoverStateIcon(std::unique_ptr<Drawable>(
+      Drawable::createFromImageData(binary_data::delete_icon_red_svg,
+                                    binary_data::delete_icon_red_svgSize)));
+  removeButton_->setColour(EarButton::highlightColourId,
+                            EarColours::Transparent);
+  removeButton_->setColour(EarButton::backgroundColourId,
+                            EarColours::Transparent);
+  removeButton_->setColour(EarButton::hoverColourId, EarColours::Transparent);
+
+  addAndMakeVisible(removeButton_.get());
+
+  removeMouseListener(this);
+  addMouseListener(this, true);
+}
+
+void ElementView::paint(Graphics& g) {
+  g.fillAll(EarColours::ObjectItemBackground);
+  if (isMouseOver(true)) {
+    g.fillAll(EarColours::Area02dp);
+  }
+}
+
+void ElementView::mouseDown(const MouseEvent& event) {
+  DragAndDropContainer* dragContainer =
+      DragAndDropContainer::findParentDragContainerFor(this);
+
+  if (handleButton_->isMouseOver() && !dragContainer->isDragAndDropActive()) {
+    auto dragStartOffset_ =
+        -getLocalPoint(event.eventComponent, event.getPosition());
+    auto image = createComponentSnapshot(getLocalBounds());
+    image.multiplyAllAlphas(Emphasis::medium);
+    dragContainer->startDragging("element", this, image, true,
+                                  &dragStartOffset_);
+    setAlpha(Emphasis::disabled);
+  }
+}
+
+void ElementView::mouseEnter(const MouseEvent& event) {
+  repaint();
+}
+
+void ElementView::mouseExit(const MouseEvent& event) {
+  repaint();
+}
+
+void ElementView::mouseUp(const MouseEvent& event) {
+  setAlpha(Emphasis::full);
+}
+
+void ElementView::resized() {
+  setSize(getParentWidth(), 100);
+}
+
+EarButton* ElementView::getHandleButton() {
+  return handleButton_.get();
+}
+
+EarButton* ElementView::getRemoveButton() {
+  return removeButton_.get();
+}
+
+}  // namespace ui
+}  // namespace plugin
+}  // namespace ear

--- a/ear-production-suite/plugins/scene/src/element_view.hpp
+++ b/ear-production-suite/plugins/scene/src/element_view.hpp
@@ -2,8 +2,7 @@
 
 #include "JuceHeader.h"
 
-#include "../../shared/components/look_and_feel/colours.hpp"
-#include "../../shared/components/look_and_feel/fonts.hpp"
+#include "../../shared/components/ear_button.hpp"
 
 #include <memory>
 
@@ -13,69 +12,21 @@ namespace ui {
 
 class ElementView : public Component {
  public:
-  ElementView()
-      : handleButton_(std::make_unique<EarButton>()),
-        removeButton_(std::make_unique<EarButton>()) {
-    handleButton_->setOffStateIcon(std::unique_ptr<Drawable>(
-        Drawable::createFromImageData(binary_data::drag_handle_icon_svg,
-                                      binary_data::drag_handle_icon_svgSize)));
-    handleButton_->setColour(EarButton::highlightColourId,
-                             EarColours::Transparent);
-    handleButton_->setColour(EarButton::backgroundColourId,
-                             EarColours::Transparent);
-    handleButton_->setColour(EarButton::hoverColourId, EarColours::Transparent);
-    addAndMakeVisible(handleButton_.get());
+  ElementView();
+  void paint(Graphics& g) override;
 
-    removeButton_->setOffStateIcon(
-        std::unique_ptr<Drawable>(Drawable::createFromImageData(
-            binary_data::delete_icon_svg, binary_data::delete_icon_svgSize)),
-        Emphasis::medium);
-    removeButton_->setHoverStateIcon(std::unique_ptr<Drawable>(
-        Drawable::createFromImageData(binary_data::delete_icon_red_svg,
-                                      binary_data::delete_icon_red_svgSize)));
-    removeButton_->setColour(EarButton::highlightColourId,
-                             EarColours::Transparent);
-    removeButton_->setColour(EarButton::backgroundColourId,
-                             EarColours::Transparent);
-    removeButton_->setColour(EarButton::hoverColourId, EarColours::Transparent);
-
-    addAndMakeVisible(removeButton_.get());
-
-    removeMouseListener(this);
-    addMouseListener(this, true);
-  }
-  void paint(Graphics& g) override {
-    g.fillAll(EarColours::ObjectItemBackground);
-    if (isMouseOver(true)) {
-      g.fillAll(EarColours::Area02dp);
-    }
-  }
-
-  void mouseDown(const MouseEvent& event) override {
-    DragAndDropContainer* dragContainer =
-        DragAndDropContainer::findParentDragContainerFor(this);
-
-    if (handleButton_->isMouseOver() && !dragContainer->isDragAndDropActive()) {
-      auto dragStartOffset_ =
-          -getLocalPoint(event.eventComponent, event.getPosition());
-      auto image = createComponentSnapshot(getLocalBounds());
-      image.multiplyAllAlphas(Emphasis::medium);
-      dragContainer->startDragging("element", this, image, true,
-                                   &dragStartOffset_);
-      setAlpha(Emphasis::disabled);
-    }
-  }
+  void mouseDown(const MouseEvent& event) override;
 
   virtual int getDesiredHeight() = 0;
 
-  void mouseEnter(const MouseEvent& event) override { repaint(); }
-  void mouseExit(const MouseEvent& event) override { repaint(); }
-  void mouseUp(const MouseEvent& event) override { setAlpha(Emphasis::full); }
+  void mouseEnter(const MouseEvent& event) override;
+  void mouseExit(const MouseEvent& event) override;
+  void mouseUp(const MouseEvent& event) override;
 
-  void resized() override { setSize(getParentWidth(), 100); }
+  void resized() override;
 
-  EarButton* getHandleButton() { return handleButton_.get(); }
-  EarButton* getRemoveButton() { return removeButton_.get(); }
+  EarButton* getHandleButton();
+  EarButton* getRemoveButton();
 
  protected:
   std::unique_ptr<EarButton> handleButton_;

--- a/ear-production-suite/plugins/scene/src/element_view_list.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.cpp
@@ -42,6 +42,7 @@ void ElementViewList::resized() {
   setSize(getParentWidth(),
           std::max(getParentHeight(), getHeightOfAllItems()));
   auto labelBounds = getLocalBounds().removeFromTop(60);
+  helpLabel_->setVisible(parentContainer->elements.size() == 0);
   helpLabel_->setBounds(labelBounds.reduced(30, 20));
   auto area = getLocalBounds();
   for (int i = 0; i < parentContainer->elements.size(); ++i) {

--- a/ear-production-suite/plugins/scene/src/element_view_list.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.cpp
@@ -106,7 +106,9 @@ void ElementViewList::itemDragMove(const SourceDetails& dragSourceDetails) {
 void ElementViewList::itemDropped(const SourceDetails& dragSourceDetails) {
   if (auto component = dragSourceDetails.sourceComponent.get()) {
     if (auto element = dynamic_cast<ElementView*>(component)) {
-      auto it = std::find(parentContainer->elements.begin(), parentContainer->elements.end(), element);
+      auto it = std::find_if(
+        parentContainer->elements.begin(), parentContainer->elements.end(),
+        [element](auto candidate) { return candidate.get() == element; });
       size_t oldIndex = std::distance(parentContainer->elements.begin(), it);
       int newIndex = dropIndex_ > oldIndex ? dropIndex_ - 1 : dropIndex_;
       parentContainer->moveElement(oldIndex, newIndex);

--- a/ear-production-suite/plugins/scene/src/element_view_list.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.cpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include "JuceHeader.h"
+
+#include "helper/move.hpp"
+#include "element_view_list.hpp"
+#include "elements_container.hpp"
+#include "../../shared/components/ear_colour_indicator.hpp"
+#include "../../shared/components/level_meter.hpp"
+#include "../../shared/components/look_and_feel/colours.hpp"
+#include "../../shared/components/look_and_feel/fonts.hpp"
+
+namespace ear {
+namespace plugin {
+namespace ui {
+
+ElementViewList::ElementViewList()
+    : dropIndicator_(std::make_unique<EarDropIndicator>()),
+      helpLabel_(std::make_unique<Label>()) {
+  addChildComponent(dropIndicator_.get());
+
+  helpLabel_->setText("Add Items by clicking the Buttons above",
+                      dontSendNotification);
+  helpLabel_->setFont(EarFonts::Items);
+  helpLabel_->setColour(Label::textColourId,
+                        EarColours::Text.withAlpha(Emphasis::medium));
+  addAndMakeVisible(helpLabel_.get());
+}
+
+void ElementViewList::paint(Graphics& g) {
+  g.fillAll(EarColours::Background);
+}
+
+void ElementViewList::parentSizeChanged() {
+  setSize(getParentWidth(),
+          std::max(getParentHeight(), getHeightOfAllItems()));
+}
+
+void ElementViewList::resized() {
+  setSize(getParentWidth(),
+          std::max(getParentHeight(), getHeightOfAllItems()));
+  auto labelBounds = getLocalBounds().removeFromTop(60);
+  helpLabel_->setBounds(labelBounds.reduced(30, 20));
+  auto area = getLocalBounds();
+  for (int i = 0; i < elements_.size(); ++i) {
+    if (dropIndicator_->isVisible() && i == dropIndex_) {
+      dropIndicator_->setBounds(
+          area.removeFromTop(indicatorHeight_).reduced(0, 2));
+      area.removeFromTop(margin_);
+    }
+    elements_.at(i)->setBounds(
+        area.removeFromTop(elements_.at(i)->getDesiredHeight()));
+    area.removeFromTop(margin_);
+  }
+  if (dropIndicator_->isVisible() && dropIndex_ == elements_.size()) {
+    dropIndicator_->setBounds(
+        area.removeFromTop(indicatorHeight_).reduced(0, 2));
+    area.removeFromTop(margin_);
+  }
+}
+
+void ElementViewList::addElement(ElementView* element) {
+  elements_.push_back(element);
+  element->getRemoveButton()->onClick = [this, element]() {
+    auto it =
+        std::find(this->elements_.begin(), this->elements_.end(), element);
+    auto index = std::distance(this->elements_.begin(), it);
+    Component::BailOutChecker checker(this);
+    listeners_.callChecked(checker, [this, index](Listener& l) {
+      l.removeElementClicked(this, index);
+    });
+    if (checker.shouldBailOut()) {
+      return;
+    }
+  };
+  addAndMakeVisible(element);
+  helpLabel_->setVisible(elements_.size() == 0);
+  resized();
+}
+
+void ElementViewList::removeElement(ElementView* item) {
+  auto it = std::find(elements_.begin(), elements_.end(), item);
+  if (it != elements_.end()) {
+    elements_.erase(it);
+    helpLabel_->setVisible(elements_.size() == 0);
+    resized();
+  }
+}
+
+int ElementViewList::getHeightOfAllItems() const {
+  int ret = 0;
+  for (const auto element : elements_) {
+    ret += element->getDesiredHeight() + margin_;
+  }
+  if (dropIndicator_->isVisible()) {
+    ret += indicatorHeight_ + margin_;
+  }
+  return ret;
+}
+
+void ElementViewList::moveElementTo(int oldIndex, int newIndex) {
+  if (oldIndex < elements_.size() && newIndex < elements_.size() &&
+      oldIndex != newIndex) {
+    move(elements_.begin(), oldIndex, newIndex);
+  }
+  Component::BailOutChecker checker(this);
+  listeners_.callChecked(checker, [this, oldIndex, newIndex](Listener& l) {
+    l.elementMoved(this, oldIndex, newIndex);
+  });
+  if (checker.shouldBailOut()) {
+    return;
+  }
+}
+
+bool ElementViewList::isInterestedInDragSource(
+    const SourceDetails& dragSourceDetails) {
+  return true;
+};
+
+void ElementViewList::itemDragEnter(const SourceDetails& dragSourceDetails) {
+  dropIndicator_->setVisible(true);
+}
+
+int ElementViewList::getDropIndexForPosition(int yPos) {
+  int y = 0;
+  int previousHeight = 0;
+  int currentHeight = 0;
+  for (int i = 0; i < elements_.size(); ++i) {
+    currentHeight = elements_.at(i)->getHeight();
+    if (y - 0.5f * previousHeight < yPos &&
+        yPos < y + 0.51f * currentHeight) {
+      return i;
+    }
+    y += currentHeight;
+    previousHeight = currentHeight;
+  }
+  return elements_.size();
+}
+
+void ElementViewList::itemDragMove(const SourceDetails& dragSourceDetails) {
+  dropIndex_ =
+      getDropIndexForPosition(dragSourceDetails.localPosition.getY());
+  resized();
+}
+
+void ElementViewList::itemDropped(const SourceDetails& dragSourceDetails) {
+  if (auto component = dragSourceDetails.sourceComponent.get()) {
+    if (auto element = dynamic_cast<ElementView*>(component)) {
+      auto it = std::find(elements_.begin(), elements_.end(), element);
+      size_t oldIndex = std::distance(elements_.begin(), it);
+      int newIndex = dropIndex_ > oldIndex ? dropIndex_ - 1 : dropIndex_;
+      moveElementTo(oldIndex, newIndex);
+    }
+  }
+  dropIndicator_->setVisible(false);
+  resized();
+}
+
+void ElementViewList::itemDragExit(const SourceDetails& dragSourceDetails) {
+  dropIndicator_->setVisible(false);
+  resized();
+}
+
+void ElementViewList::addListener(Listener* l) {
+  listeners_.add(l);
+}
+
+void ElementViewList::removeListener(Listener* l) {
+  listeners_.remove(l);
+}
+
+}  // namespace ui
+}  // namespace plugin
+}  // namespace ear

--- a/ear-production-suite/plugins/scene/src/element_view_list.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.cpp
@@ -10,15 +10,18 @@
 #include "../../shared/components/look_and_feel/colours.hpp"
 #include "../../shared/components/look_and_feel/fonts.hpp"
 
+#include <cassert>
+
 namespace ear {
 namespace plugin {
 namespace ui {
 
-ElementViewList::ElementViewList()
+ElementViewList::ElementViewList(ElementsContainer* parentContainer)
     : dropIndicator_(std::make_unique<EarDropIndicator>()),
+      parentContainer{parentContainer},
       helpLabel_(std::make_unique<Label>()) {
   addChildComponent(dropIndicator_.get());
-
+  assert(parentContainer);
   helpLabel_->setText("Add Items by clicking the Buttons above",
                       dontSendNotification);
   helpLabel_->setFont(EarFonts::Items);

--- a/ear-production-suite/plugins/scene/src/element_view_list.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.cpp
@@ -29,18 +29,14 @@ ElementViewList::ElementViewList(ElementsContainer* parentContainer)
   addAndMakeVisible(helpLabel_.get());
 }
 
-void ElementViewList::paint(Graphics& g) {
-  g.fillAll(EarColours::Background);
-}
+void ElementViewList::paint(Graphics& g) { g.fillAll(EarColours::Background); }
 
 void ElementViewList::parentSizeChanged() {
-  setSize(getParentWidth(),
-          std::max(getParentHeight(), getHeightOfAllItems()));
+  setSize(getParentWidth(), std::max(getParentHeight(), getHeightOfAllItems()));
 }
 
 void ElementViewList::resized() {
-  setSize(getParentWidth(),
-          std::max(getParentHeight(), getHeightOfAllItems()));
+  setSize(getParentWidth(), std::max(getParentHeight(), getHeightOfAllItems()));
   auto labelBounds = getLocalBounds().removeFromTop(60);
   helpLabel_->setVisible(parentContainer->elements.size() == 0);
   helpLabel_->setBounds(labelBounds.reduced(30, 20));
@@ -51,11 +47,12 @@ void ElementViewList::resized() {
           area.removeFromTop(indicatorHeight_).reduced(0, 2));
       area.removeFromTop(margin_);
     }
-    parentContainer->elements.at(i)->setBounds(
-        area.removeFromTop(parentContainer->elements.at(i)->getDesiredHeight()));
+    parentContainer->elements.at(i)->setBounds(area.removeFromTop(
+        parentContainer->elements.at(i)->getDesiredHeight()));
     area.removeFromTop(margin_);
   }
-  if (dropIndicator_->isVisible() && dropIndex_ == parentContainer->elements.size()) {
+  if (dropIndicator_->isVisible() &&
+      dropIndex_ == parentContainer->elements.size()) {
     dropIndicator_->setBounds(
         area.removeFromTop(indicatorHeight_).reduced(0, 2));
     area.removeFromTop(margin_);
@@ -88,8 +85,7 @@ int ElementViewList::getDropIndexForPosition(int yPos) {
   int currentHeight = 0;
   for (int i = 0; i < parentContainer->elements.size(); ++i) {
     currentHeight = parentContainer->elements.at(i)->getHeight();
-    if (y - 0.5f * previousHeight < yPos &&
-        yPos < y + 0.51f * currentHeight) {
+    if (y - 0.5f * previousHeight < yPos && yPos < y + 0.51f * currentHeight) {
       return i;
     }
     y += currentHeight;
@@ -99,8 +95,7 @@ int ElementViewList::getDropIndexForPosition(int yPos) {
 }
 
 void ElementViewList::itemDragMove(const SourceDetails& dragSourceDetails) {
-  dropIndex_ =
-      getDropIndexForPosition(dragSourceDetails.localPosition.getY());
+  dropIndex_ = getDropIndexForPosition(dragSourceDetails.localPosition.getY());
   resized();
 }
 
@@ -108,8 +103,8 @@ void ElementViewList::itemDropped(const SourceDetails& dragSourceDetails) {
   if (auto component = dragSourceDetails.sourceComponent.get()) {
     if (auto element = dynamic_cast<ElementView*>(component)) {
       auto it = std::find_if(
-        parentContainer->elements.begin(), parentContainer->elements.end(),
-        [element](auto candidate) { return candidate.get() == element; });
+          parentContainer->elements.begin(), parentContainer->elements.end(),
+          [element](auto candidate) { return candidate.get() == element; });
       size_t oldIndex = std::distance(parentContainer->elements.begin(), it);
       int newIndex = dropIndex_ > oldIndex ? dropIndex_ - 1 : dropIndex_;
       parentContainer->moveElement(oldIndex, newIndex);

--- a/ear-production-suite/plugins/scene/src/element_view_list.cpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.cpp
@@ -38,7 +38,7 @@ void ElementViewList::parentSizeChanged() {
 void ElementViewList::resized() {
   setSize(getParentWidth(), std::max(getParentHeight(), getHeightOfAllItems()));
   auto labelBounds = getLocalBounds().removeFromTop(60);
-  helpLabel_->setVisible(parentContainer->elements.size() == 0);
+  helpLabel_->setVisible(parentContainer->elements.empty());
   helpLabel_->setBounds(labelBounds.reduced(30, 20));
   auto area = getLocalBounds();
   for (int i = 0; i < parentContainer->elements.size(); ++i) {
@@ -61,7 +61,7 @@ void ElementViewList::resized() {
 
 int ElementViewList::getHeightOfAllItems() const {
   int ret = 0;
-  for (const auto element : parentContainer->elements) {
+  for (const auto& element : parentContainer->elements) {
     ret += element->getDesiredHeight() + margin_;
   }
   if (dropIndicator_->isVisible()) {

--- a/ear-production-suite/plugins/scene/src/element_view_list.hpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.hpp
@@ -10,7 +10,6 @@ namespace ear {
 namespace plugin {
 namespace ui {
 
-class ElementView;
 class ElementsContainer;
 
 class ElementViewList : public Component,
@@ -25,13 +24,7 @@ class ElementViewList : public Component,
 
   void resized() override;
 
-  void addElement(ElementView* element);
-
-  void removeElement(ElementView* item);
-
   int getHeightOfAllItems() const;
-
-  void moveElementTo(int oldIndex, int newIndex);
 
   bool isInterestedInDragSource(
     const SourceDetails& dragSourceDetails) override;
@@ -46,20 +39,7 @@ class ElementViewList : public Component,
 
   void itemDragExit(const SourceDetails& dragSourceDetails) override;
 
-  class Listener {
-   public:
-    virtual ~Listener() = default;
-
-    virtual void elementMoved(ElementViewList* list, int oldIndex,
-                              int newIndex) = 0;
-    virtual void removeElementClicked(ElementViewList* list, int index) = 0;
-  };
-
-  void addListener(Listener* l);
-  void removeListener(Listener* l);
-
  private:
-  std::vector<ElementView*> elements_;
   std::unique_ptr<EarDropIndicator> dropIndicator_;
   std::unique_ptr<Label> helpLabel_;
 
@@ -69,8 +49,6 @@ class ElementViewList : public Component,
 
   const int indicatorHeight_ = 6;
   const int margin_ = 1;
-
-  ListenerList<Listener> listeners_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ElementViewList)
 };

--- a/ear-production-suite/plugins/scene/src/element_view_list.hpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.hpp
@@ -2,11 +2,6 @@
 
 #include "JuceHeader.h"
 
-#include "helper/move.hpp"
-#include "../../shared/components/ear_colour_indicator.hpp"
-#include "../../shared/components/level_meter.hpp"
-#include "../../shared/components/look_and_feel/colours.hpp"
-#include "../../shared/components/look_and_feel/fonts.hpp"
 #include "ear_drop_indicator.hpp"
 
 #include <memory>
@@ -15,154 +10,40 @@ namespace ear {
 namespace plugin {
 namespace ui {
 
+class ElementView;
+
 class ElementViewList : public Component,
                         public DragAndDropTarget,
                         public DragAndDropContainer {
  public:
-  ElementViewList()
-      : dropIndicator_(std::make_unique<EarDropIndicator>()),
-        helpLabel_(std::make_unique<Label>()) {
-    addChildComponent(dropIndicator_.get());
+  ElementViewList();
 
-    helpLabel_->setText("Add Items by clicking the Buttons above",
-                        dontSendNotification);
-    helpLabel_->setFont(EarFonts::Items);
-    helpLabel_->setColour(Label::textColourId,
-                          EarColours::Text.withAlpha(Emphasis::medium));
-    addAndMakeVisible(helpLabel_.get());
-  }
+  void paint(Graphics& g) override;
 
-  void paint(Graphics& g) override { g.fillAll(EarColours::Background); }
+  void parentSizeChanged() override;
 
-  void parentSizeChanged() override {
-    setSize(getParentWidth(),
-            std::max(getParentHeight(), getHeightOfAllItems()));
-  }
+  void resized() override;
 
-  void resized() override {
-    setSize(getParentWidth(),
-            std::max(getParentHeight(), getHeightOfAllItems()));
-    auto labelBounds = getLocalBounds().removeFromTop(60);
-    helpLabel_->setBounds(labelBounds.reduced(30, 20));
-    auto area = getLocalBounds();
-    for (int i = 0; i < elements_.size(); ++i) {
-      if (dropIndicator_->isVisible() && i == dropIndex_) {
-        dropIndicator_->setBounds(
-            area.removeFromTop(indicatorHeight_).reduced(0, 2));
-        area.removeFromTop(margin_);
-      }
-      elements_.at(i)->setBounds(
-          area.removeFromTop(elements_.at(i)->getDesiredHeight()));
-      area.removeFromTop(margin_);
-    }
-    if (dropIndicator_->isVisible() && dropIndex_ == elements_.size()) {
-      dropIndicator_->setBounds(
-          area.removeFromTop(indicatorHeight_).reduced(0, 2));
-      area.removeFromTop(margin_);
-    }
-  }
+  void addElement(ElementView* element);
 
-  void addElement(ElementView* element) {
-    elements_.push_back(element);
-    element->getRemoveButton()->onClick = [this, element]() {
-      auto it =
-          std::find(this->elements_.begin(), this->elements_.end(), element);
-      auto index = std::distance(this->elements_.begin(), it);
-      Component::BailOutChecker checker(this);
-      listeners_.callChecked(checker, [this, index](Listener& l) {
-        l.removeElementClicked(this, index);
-      });
-      if (checker.shouldBailOut()) {
-        return;
-      }
-    };
-    addAndMakeVisible(element);
-    helpLabel_->setVisible(elements_.size() == 0);
-    resized();
-  }
+  void removeElement(ElementView* item);
 
-  void removeElement(ElementView* item) {
-    auto it = std::find(elements_.begin(), elements_.end(), item);
-    if (it != elements_.end()) {
-      elements_.erase(it);
-      helpLabel_->setVisible(elements_.size() == 0);
-      resized();
-    }
-  }
+  int getHeightOfAllItems() const;
 
-  int getHeightOfAllItems() const {
-    int ret = 0;
-    for (const auto element : elements_) {
-      ret += element->getDesiredHeight() + margin_;
-    }
-    if (dropIndicator_->isVisible()) {
-      ret += indicatorHeight_ + margin_;
-    }
-    return ret;
-  }
-
-  void moveElementTo(int oldIndex, int newIndex) {
-    if (oldIndex < elements_.size() && newIndex < elements_.size() &&
-        oldIndex != newIndex) {
-      move(elements_.begin(), oldIndex, newIndex);
-    }
-    Component::BailOutChecker checker(this);
-    listeners_.callChecked(checker, [this, oldIndex, newIndex](Listener& l) {
-      l.elementMoved(this, oldIndex, newIndex);
-    });
-    if (checker.shouldBailOut()) {
-      return;
-    }
-  }
+  void moveElementTo(int oldIndex, int newIndex);
 
   bool isInterestedInDragSource(
-      const SourceDetails& dragSourceDetails) override {
-    return true;
-  };
+    const SourceDetails& dragSourceDetails) override;
 
-  void itemDragEnter(const SourceDetails& dragSourceDetails) override {
-    dropIndicator_->setVisible(true);
-  }
+  void itemDragEnter(const SourceDetails& dragSourceDetails) override;
 
-  int getDropIndexForPosition(int yPos) {
-    int y = 0;
-    int previousHeight = 0;
-    int currentHeight = 0;
-    for (int i = 0; i < elements_.size(); ++i) {
-      currentHeight = elements_.at(i)->getHeight();
-      if (y - 0.5f * previousHeight < yPos &&
-          yPos < y + 0.51f * currentHeight) {
-        return i;
-      }
-      y += currentHeight;
-      previousHeight = currentHeight;
-    }
-    return elements_.size();
-  }
+  int getDropIndexForPosition(int yPos);
 
-  void itemDragMove(const SourceDetails& dragSourceDetails) override {
-    dropIndex_ =
-        getDropIndexForPosition(dragSourceDetails.localPosition.getY());
-    resized();
-  }
+  void itemDragMove(const SourceDetails& dragSourceDetails) override;
 
-  void itemDropped(const SourceDetails& dragSourceDetails) override {
-    if (auto component = dragSourceDetails.sourceComponent.get()) {
-      if (auto element = dynamic_cast<ElementView*>(component)) {
-        auto it = std::find(elements_.begin(), elements_.end(), element);
-        size_t oldIndex = std::distance(elements_.begin(), it);
-        int newIndex = dropIndex_ > oldIndex ? dropIndex_ - 1 : dropIndex_;
-        moveElementTo(oldIndex, newIndex);
-      }
-    }
-    dropIndicator_->setVisible(false);
-    resized();
-  }
+  void itemDropped(const SourceDetails& dragSourceDetails) override;
 
-  void itemDragExit(const SourceDetails& dragSourceDetails) override {
-    dropIndicator_->setVisible(false);
-    resized();
-  }
+  void itemDragExit(const SourceDetails& dragSourceDetails) override;
 
   class Listener {
    public:
@@ -173,8 +54,8 @@ class ElementViewList : public Component,
     virtual void removeElementClicked(ElementViewList* list, int index) = 0;
   };
 
-  void addListener(Listener* l) { listeners_.add(l); }
-  void removeListener(Listener* l) { listeners_.remove(l); }
+  void addListener(Listener* l);
+  void removeListener(Listener* l);
 
  private:
   std::vector<ElementView*> elements_;
@@ -189,7 +70,7 @@ class ElementViewList : public Component,
   ListenerList<Listener> listeners_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ElementViewList)
-};  // namespace ui
+};
 
 }  // namespace ui
 }  // namespace plugin

--- a/ear-production-suite/plugins/scene/src/element_view_list.hpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.hpp
@@ -11,12 +11,13 @@ namespace plugin {
 namespace ui {
 
 class ElementView;
+class ElementsContainer;
 
 class ElementViewList : public Component,
                         public DragAndDropTarget,
                         public DragAndDropContainer {
  public:
-  ElementViewList();
+  ElementViewList(ElementsContainer* parentContainer);
 
   void paint(Graphics& g) override;
 
@@ -61,6 +62,8 @@ class ElementViewList : public Component,
   std::vector<ElementView*> elements_;
   std::unique_ptr<EarDropIndicator> dropIndicator_;
   std::unique_ptr<Label> helpLabel_;
+
+  ElementsContainer* parentContainer;
 
   int dropIndex_ = 0;
 

--- a/ear-production-suite/plugins/scene/src/element_view_list.hpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.hpp
@@ -27,7 +27,7 @@ class ElementViewList : public Component,
   int getHeightOfAllItems() const;
 
   bool isInterestedInDragSource(
-    const SourceDetails& dragSourceDetails) override;
+      const SourceDetails& dragSourceDetails) override;
 
   void itemDragEnter(const SourceDetails& dragSourceDetails) override;
 

--- a/ear-production-suite/plugins/scene/src/element_view_list.hpp
+++ b/ear-production-suite/plugins/scene/src/element_view_list.hpp
@@ -16,7 +16,7 @@ class ElementViewList : public Component,
                         public DragAndDropTarget,
                         public DragAndDropContainer {
  public:
-  ElementViewList(ElementsContainer* parentContainer);
+  explicit ElementViewList(ElementsContainer* parentContainer);
 
   void paint(Graphics& g) override;
 

--- a/ear-production-suite/plugins/scene/src/elements_container.cpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.cpp
@@ -9,8 +9,8 @@ namespace plugin {
 namespace ui {
 
 ElementsContainer::ElementsContainer()
-    : viewport(std::make_unique<Viewport>()),
-      list(std::make_unique<ElementViewList>()) {
+    : viewport(std::make_unique<Viewport>()) {
+  list = std::make_unique<ElementViewList>(this);
   viewport->setViewedComponent(list.get(), false);
   viewport->setScrollBarsShown(true, false);
   viewport->getVerticalScrollBar().setColour(ScrollBar::thumbColourId,

--- a/ear-production-suite/plugins/scene/src/elements_container.cpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.cpp
@@ -2,6 +2,8 @@
 
 #include "elements_container.hpp"
 
+#include "helper/move.hpp"
+
 namespace ear {
 namespace plugin {
 namespace ui {
@@ -24,6 +26,54 @@ void ElementsContainer::resized() {
   auto area = getLocalBounds();
   viewport->setBounds(area.reduced(2, 2));
   list->setBounds(area.reduced(2, 2));
+}
+
+void ElementsContainer::removeElement(ElementView* element) {
+  auto it = std::find_if(
+    elements.begin(), elements.end(),
+    [element](auto candidate) { return candidate.get() == element; });
+  auto index = std::distance(elements.begin(), it);
+  elements.erase(it);
+  list->removeChildComponent(element);
+  list->resized();
+  Component::BailOutChecker checker(this);
+  listeners_.callChecked(checker, [this, index](Listener& l) {
+    l.removeElementClicked(this->list.get(), index);
+  });
+  if (checker.shouldBailOut()) {
+    return;
+  }
+}
+
+void ElementsContainer::moveElement(int oldIndex, int newIndex) {
+  if (oldIndex < elements.size() && newIndex < elements.size() &&
+      oldIndex != newIndex) {
+    move(elements.begin(), oldIndex, newIndex);
+  }
+  Component::BailOutChecker checker(this);
+  listeners_.callChecked(checker, [this, oldIndex, newIndex](Listener& l) {
+    l.elementMoved(this->list.get(), oldIndex, newIndex);
+  });
+  if (checker.shouldBailOut()) {
+    return;
+  }
+}
+
+void ElementsContainer::addElement(std::shared_ptr<ElementView> element) {
+  element->getRemoveButton()->onClick = [this, element]() {
+    removeElement(element.get());
+  };
+  elements.push_back(element);
+  list->addAndMakeVisible(element.get());
+  resized();
+}
+
+void ElementsContainer::addListener(Listener* l) {
+  listeners_.add(l);
+}
+
+void ElementsContainer::removeListener(Listener* l) {
+  listeners_.remove(l);
 }
 
 }  // namespace ui

--- a/ear-production-suite/plugins/scene/src/elements_container.cpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.cpp
@@ -14,7 +14,7 @@ ElementsContainer::ElementsContainer()
   viewport->setViewedComponent(list.get(), false);
   viewport->setScrollBarsShown(true, false);
   viewport->getVerticalScrollBar().setColour(ScrollBar::thumbColourId,
-                                              EarColours::Area04dp);
+                                             EarColours::Area04dp);
   addAndMakeVisible(viewport.get());
 }
 
@@ -30,8 +30,8 @@ void ElementsContainer::resized() {
 
 void ElementsContainer::removeElement(ElementView* element) {
   auto it = std::find_if(
-    elements.begin(), elements.end(),
-    [element](auto candidate) { return candidate.get() == element; });
+      elements.begin(), elements.end(),
+      [element](auto candidate) { return candidate.get() == element; });
   auto index = std::distance(elements.begin(), it);
   elements.erase(it);
   list->removeChildComponent(element);
@@ -68,13 +68,9 @@ void ElementsContainer::addElement(std::shared_ptr<ElementView> element) {
   resized();
 }
 
-void ElementsContainer::addListener(Listener* l) {
-  listeners_.add(l);
-}
+void ElementsContainer::addListener(Listener* l) { listeners_.add(l); }
 
-void ElementsContainer::removeListener(Listener* l) {
-  listeners_.remove(l);
-}
+void ElementsContainer::removeListener(Listener* l) { listeners_.remove(l); }
 
 }  // namespace ui
 }  // namespace plugin

--- a/ear-production-suite/plugins/scene/src/elements_container.cpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.cpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "elements_container.hpp"
+
+namespace ear {
+namespace plugin {
+namespace ui {
+
+ElementsContainer::ElementsContainer()
+    : viewport(std::make_unique<Viewport>()),
+      list(std::make_unique<ElementViewList>()) {
+  viewport->setViewedComponent(list.get(), false);
+  viewport->setScrollBarsShown(true, false);
+  viewport->getVerticalScrollBar().setColour(ScrollBar::thumbColourId,
+                                              EarColours::Area04dp);
+  addAndMakeVisible(viewport.get());
+}
+
+void ElementsContainer::paint(Graphics& g) {
+  g.fillAll(EarColours::ComboBoxPopupBackground);
+}
+
+void ElementsContainer::resized() {
+  auto area = getLocalBounds();
+  viewport->setBounds(area.reduced(2, 2));
+  list->setBounds(area.reduced(2, 2));
+}
+
+}  // namespace ui
+}  // namespace plugin
+}  // namespace ear

--- a/ear-production-suite/plugins/scene/src/elements_container.hpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.hpp
@@ -35,8 +35,8 @@ class ElementsContainer : public Component {
   void addListener(Listener* l);
   void removeListener(Listener* l);
 
-  std::unique_ptr<Viewport> viewport;
   std::unique_ptr<ElementViewList> list;
+  std::unique_ptr<Viewport> viewport;
   std::vector<std::shared_ptr<ElementView>> elements;
 
  private:

--- a/ear-production-suite/plugins/scene/src/elements_container.hpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.hpp
@@ -19,11 +19,28 @@ class ElementsContainer : public Component {
 
   void resized() override;
 
+  void addElement(std::shared_ptr<ElementView> element);
+  void removeElement(ElementView* element);
+  void moveElement(int oldIndex, int newIndex);
+
+  class Listener {
+   public:
+    virtual ~Listener() = default;
+
+    virtual void elementMoved(ElementViewList* list, int oldIndex,
+                              int newIndex) = 0;
+    virtual void removeElementClicked(ElementViewList* list, int index) = 0;
+  };
+
+  void addListener(Listener* l);
+  void removeListener(Listener* l);
+
   std::unique_ptr<Viewport> viewport;
   std::unique_ptr<ElementViewList> list;
   std::vector<std::shared_ptr<ElementView>> elements;
 
  private:
+  ListenerList<Listener> listeners_;
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ElementsContainer)
 };
 

--- a/ear-production-suite/plugins/scene/src/elements_container.hpp
+++ b/ear-production-suite/plugins/scene/src/elements_container.hpp
@@ -13,25 +13,11 @@ namespace ui {
 
 class ElementsContainer : public Component {
  public:
-  ElementsContainer()
-      : viewport(std::make_unique<Viewport>()),
-        list(std::make_unique<ElementViewList>()) {
-    viewport->setViewedComponent(list.get(), false);
-    viewport->setScrollBarsShown(true, false);
-    viewport->getVerticalScrollBar().setColour(ScrollBar::thumbColourId,
-                                               EarColours::Area04dp);
-    addAndMakeVisible(viewport.get());
-  }
+  ElementsContainer();
 
-  void paint(Graphics& g) override {
-    g.fillAll(EarColours::ComboBoxPopupBackground);
-  }
+  void paint(Graphics& g) override;
 
-  void resized() override {
-    auto area = getLocalBounds();
-    viewport->setBounds(area.reduced(2, 2));
-    list->setBounds(area.reduced(2, 2));
-  }
+  void resized() override;
 
   std::unique_ptr<Viewport> viewport;
   std::unique_ptr<ElementViewList> list;

--- a/ear-production-suite/plugins/scene/src/scene_frontend_connector.cpp
+++ b/ear-production-suite/plugins/scene/src/scene_frontend_connector.cpp
@@ -157,7 +157,7 @@ void JuceSceneFrontendConnector::reloadProgrammeCache() {
   if (auto overlay = autoModeOverlay_.lock()) {
     overlay->setVisible(autoMode);
   }
-  selectProgramme(selectedProgramme);
+  //selectProgramme(selectedProgramme); - selectProgrammeView will trigger selectProgramme anyway
   selectProgrammeView(selectedProgramme);
 }
 

--- a/ear-production-suite/plugins/scene/src/scene_frontend_connector.cpp
+++ b/ear-production-suite/plugins/scene/src/scene_frontend_connector.cpp
@@ -430,7 +430,7 @@ void JuceSceneFrontendConnector::removeFromProgrammes(
       auto elementIndex = std::distance(elements->begin(), element);
       elements->erase(elements->begin() + elementIndex);
       notifyProgrammeStoreChanged(p_->getProgrammeStoreCopy());
-      
+
       std::lock_guard<std::mutex> programmeViewsLock(programmeViewsMutex_);
       updateElementOverview(programmeIndex);
     }
@@ -457,8 +457,7 @@ void JuceSceneFrontendConnector::removeFromObjectViews(
             return false;
           });
       if (it != container->elements.end()) {
-        container->list->removeElement(it->get());
-        container->elements.erase(it);
+        container->removeElement(it->get());
       }
     }
   }
@@ -484,7 +483,7 @@ void JuceSceneFrontendConnector::addProgrammeView(
     view->getLanguageComboBox()->selectEntry(
         getIndexForAlpha3(programme.language()), dontSendNotification);
     view->addListener(this);
-    view->getElementsContainer()->list->addListener(this);
+    view->getElementsContainer()->addListener(this);
     view->getElementOverview()->setProgramme(programme, itemStore_);
     container->programmes.push_back(view);
     container->tabs->addTab(programme.name(), view.get(), false);
@@ -784,8 +783,7 @@ void JuceSceneFrontendConnector::addObjectView(int programmeIndex,
     std::vector<int> routing(numberOfChannels);
     std::iota(routing.begin(), routing.end(), item.routing());
     view->getLevelMeter()->setMeter(p_->getLevelMeter(), routing);
-    container->list->addElement(view.get());
-    container->elements.push_back(view);
+    container->addElement(view);
   }
 }
 
@@ -825,19 +823,7 @@ void JuceSceneFrontendConnector::removeElement(int programmeIndex,
   notifyProgrammeStoreChanged(p_->getProgrammeStoreCopy());
 }
 
-void JuceSceneFrontendConnector::removeElementView(int programmeIndex,
-                                                   int elementIndex) {
-  std::lock_guard<std::mutex> programmeViewsLock(programmeViewsMutex_);
-  if (auto programmesContainer = programmesContainer_.lock()) {
-    auto container = programmesContainer->programmes.at(programmeIndex)
-                         ->getElementsContainer();
-    container->list->removeElement(
-        (container->elements.begin() + elementIndex)->get());
-    container->elements.erase(container->elements.begin() + elementIndex);
-  }
-}
-
-// ElementViewList::Listener
+// ElementsContainer::Listener
 void JuceSceneFrontendConnector::elementMoved(ElementViewList* list,
                                               int oldIndex, int newIndex) {
   int programmeIndex = -1;
@@ -874,7 +860,6 @@ void JuceSceneFrontendConnector::removeElementClicked(ElementViewList* list,
   }
   assert(programmeIndex >= 0);
   removeElement(programmeIndex, index);
-  removeElementView(programmeIndex, index);
   updateElementOverview(programmeIndex);
 }
 

--- a/ear-production-suite/plugins/scene/src/scene_frontend_connector.hpp
+++ b/ear-production-suite/plugins/scene/src/scene_frontend_connector.hpp
@@ -29,7 +29,7 @@ class ToggleView;
 
 class JuceSceneFrontendConnector : public SceneFrontendBackendConnector,
                                    private ProgrammeView::Listener,
-                                   private ElementViewList::Listener,
+                                   private ElementsContainer::Listener,
                                    private ItemsContainer::Listener,
                                    private AutoModeOverlay::Listener,
                                    private EarTabbedComponent::Listener,
@@ -92,7 +92,6 @@ class JuceSceneFrontendConnector : public SceneFrontendBackendConnector,
   void addToggleView(int programmeIndex, const proto::Toggle& toggle);
   void moveElement(int programmeIndex, int oldIndex, int newIndex);
   void removeElement(int programmeIndex, int elmentIndex);
-  void removeElementView(int programmeIndex, int elmentIndex);
 
   // --- ElementOverview
   void updateElementOverview(int programmeIndex);


### PR DESCRIPTION
Closes #87 

`ElementViewList` maintained a `std::vector<ElementView*> elements_;`, and `ElementsContainer` also maintained a `std::vector<std::shared_ptr<ElementView>> elements;` - these could get out of sync, and hence why the UI appeared to be deleting the wrong item.

The easy fix would have been to modify the `JuceSceneFrontendConnector::elementMoved` method to ensure it updates the ordering of vector elements in the `ElementViewList` (which it already did) **AND** the vector of elements in `ElementsContainer` such that the indices always matched and operations were always enacted on the correct vector elements.

However, it seemed redundant to me to be maintaining two vectors. It seems much more logical to just use the vector in `ElementsContainer`, and all operations concerning adding, moving and removing elements to be handled by `ElementsContainer` (this also meant moving the listeners to `ElementsContainer` too).