### PR TITLE
CI: Build on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - 'main'
     tags:
       - '*'
 


### PR DESCRIPTION
#98 Updated CI to be a bit less enthusiastic, but accidentally disabled building after a PR merge. This should fix that with a little luck.