### PR TITLE
Fix export channel check for updated DirectSpeakers plugin

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
@@ -86,7 +86,7 @@ public:
 private:
     // TODO: Fix hard-coded values - pull from plugin suite
     std::unique_ptr<PluginParameter> paramTrackMapping{ createPluginParameter(0, { -1.0, 63.0 }) };
-    std::unique_ptr<PluginParameter> paramSpeakerLayout{ createPluginParameter(1, { -1.0, 13.0 }) };
+    std::unique_ptr<PluginParameter> paramSpeakerLayout{ createPluginParameter(1, { -1.0, 21.0 }) };
 
     // Statics
 


### PR DESCRIPTION
This fixes a regression after the DirectSpeakers plugin was updated to support
more channel layouts. The max value of paramSpeakerLayout had not been updated
to reflect the new layout count. As the comment above the changed code suggests, we should consolidate
this stuff in one place, but leaving that for now as this is an urgent fix.