### PR TITLE
2+7+0 Crash fix

### DIFF
--- a/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
@@ -36,8 +36,8 @@ namespace {
                                              channels_4_9_0.begin() + 8);
     auto channels_9_10_3 = ear::getLayout("9+10+3").channels();
     // The last two are U+090 and U-090, which we take from 9_10_3 at 11/12
-    channels_2_7_0.push_back(channels_9_10_3.at(11));
     channels_2_7_0.push_back(channels_9_10_3.at(12));
+    channels_2_7_0.push_back(channels_9_10_3.at(13));
     return {"2+7+0", channels_2_7_0};
   } else {
     return ear::getLayout(layout);

--- a/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
@@ -64,12 +64,13 @@ EarMonitoringAudioProcessor::_getBusProperties() {
 //==============================================================================
 EarMonitoringAudioProcessor::EarMonitoringAudioProcessor()
     : AudioProcessor(_getBusProperties()) {
+  auto speakerLayout = layout();
   backend_ = std::make_unique<ear::plugin::MonitoringBackend>(
-      nullptr, ear::getLayout(SPEAKER_LAYOUT), 64);
+      nullptr, speakerLayout, 64);
   levelMeter_ = std::make_shared<ear::plugin::LevelMeterCalculator>(0, 0);
   ProcessorConfig newConfig{getTotalNumInputChannels(),
                             getTotalNumOutputChannels(), 512,
-                            ear::getLayout(SPEAKER_LAYOUT)};
+                            speakerLayout};
   configureProcessor(newConfig);
 }
 


### PR DESCRIPTION
First crash caused by using ear::getLayout during constructor, which throws because the lookup fails.

Second crash was a ear::internal_error "collinear points in convex hull" due to wrong channels pulled from 9_10_3 setup