### PR TITLE
Build minimal plugin set on win RelWithDebInfo CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -95,6 +95,16 @@
       }
     },
     {
+      "name": "minimal-build-base",
+      "hidden": true,
+      "cacheVariables": {
+        "EAR_PLUGINS_BUILD_ALL_MONITORING_PLUGINS": {
+          "type": "BOOL",
+          "value": "false"
+        }
+      }
+    },
+    {
       "name": "vcpkg-windows-x64",
       "hidden": true,
       "inherits": ["vcpkg-base", "windows-base"],
@@ -157,7 +167,8 @@
       "inherits": [
         "vcpkg-windows-x64",
         "packaging-base",
-        "relwithdebinfo-base"
+        "relwithdebinfo-base",
+        "minimal-build-base"
       ]
     },
     {


### PR DESCRIPTION
We're running out of space on the GitHub runners when building all the
plugins and generating pdb files, so just build the stereo monitoring
plugin which should cover most cases this build type is used for.