### PR TITLE
Fix combobox unselect bug

### DIFF
--- a/shared/components/ear_combo_box.cpp
+++ b/shared/components/ear_combo_box.cpp
@@ -159,8 +159,8 @@ void EarComboBoxPopup::addEntry(std::unique_ptr<EarComboBoxEntry> entry) {
 
 bool EarComboBoxPopup::selectEntry(int index) {
   if (index < entries_.size()) {
+    clearSelection();
     if (entries_.at(index)->isSelectable()) {
-      clearSelection();
       entries_.at(index)->setSelected(true);
       return true;
     }


### PR DESCRIPTION
When the UI is first shown, the frontend connector sets the selected entry in each combobox. It does this by passing in it's cached var to `selectEntry()`. Initially, this is garbage as it hasn't had anything stored in it. The `selectEntry()` method would see that it isn't a selectable entry index and do nothing. The Frontend Connector then receives a real value, updates it's cached var and passes this to `selectEntry()`. In some cases this is -1, meaning unselected, but the `selectEntry()` method sees that as not a selectable entry and does nothing, leaving the combobox in the state it was already in, which was unselected.

This is why it appears to work fine, but really, we've just been getting away with it. If you build in debug where ints are initialised to 0, the first call to `selectEntry()` is 0, which is selectable, and so is selected. The cached var is updated with a real value, which is often -1, meaning unselected. This is passed to `selectEntry()` which sees that -1 is not a selectable entry and does nothing (not even the unselect).

Fix is to always clear the selection regardless of whether the incoming value will be selectable or not. 