### PR TITLE
Fix build issues with new Win SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,11 @@ jobs:
 
       - name: 'Windows: set up developer environment'
         uses: ilammy/msvc-dev-cmd@v1
+        # Temporarily force SDK to 10.0.19041.0. 
+        # WindowsSDKVersion: 10.0.20348.0 does not compile with VSCMD_VER: 16.11.2
+        # See https://developercommunity.visualstudio.com/t/code-using-windows-10-sdk-100203480-cant-be-compil/1521695
+        with:
+          sdk: 10.0.19041.0
         if: matrix.config.os == 'windows-latest'
 
       - name: 'Configure with CMake, vcpkg and ccmake.'


### PR DESCRIPTION
Getting lots of;
`C:\Program Files (x86)\Windows Kits\10\include\10.0.20348.0\um\mapi.h(xxx): error C2279: exception specification cannot appear in a typedef declaration`
...since SDK moved from 10.0.19041.0 to 10.0.20348.0

Also see https://developercommunity.visualstudio.com/t/code-using-windows-10-sdk-100203480-cant-be-compil/1521695 (no solution provided however)