### PR TITLE
Metadata update issues

### DIFF
--- a/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
@@ -7,6 +7,7 @@
 #include <ear/ear.hpp>
 #include <Eigen/Eigen>
 #include <map>
+#include <string>
 #include <vector>
 
 namespace ear {
@@ -50,6 +51,7 @@ class SceneGainsCalculator {
   ear::GainCalculatorObjects objectCalculator_;
   ear::GainCalculatorDirectSpeakers directSpeakersCalculator_;
   std::map<communication::ConnectionId, Routing> routingCache_;
+  std::vector<std::string> allActiveIds;
 };
 
 }  // namespace plugin

--- a/ear-production-suite-plugins/lib/src/communication/direct_speakers_metadata_sender.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/direct_speakers_metadata_sender.cpp
@@ -123,6 +123,7 @@ void DirectSpeakersMetadataSender::colour(int value) {
 }
 void DirectSpeakersMetadataSender::speakerSetupIndex(int value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.set_allocated_ds_metadata(
       proto::convertSpeakerSetupToEpsMetadata(value));
 }

--- a/ear-production-suite-plugins/lib/src/communication/object_metadata_sender.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/object_metadata_sender.cpp
@@ -138,31 +138,37 @@ void ObjectMetadataSender::elevation(float value) {
 }
 void ObjectMetadataSender::distance(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->mutable_position()->set_distance(value);
 }
-
 void ObjectMetadataSender::width(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->set_width(value);
 }
 void ObjectMetadataSender::height(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->set_height(value);
 }
 void ObjectMetadataSender::depth(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->set_depth(value);
 }
 void ObjectMetadataSender::diffuse(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->set_diffuse(value);
 }
 void ObjectMetadataSender::factor(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->set_factor(value);
 }
 void ObjectMetadataSender::range(float value) {
   std::lock_guard<std::mutex> lock(dataMutex_);
+  data_.set_changed(true);
   data_.mutable_obj_metadata()->set_range(value);
 }
 

--- a/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
@@ -1,6 +1,7 @@
 #include "scene_gains_calculator.hpp"
 #include "ear/metadata.hpp"
 #include "helper/eps_to_ear_metadata_converter.hpp"
+#include <algorithm>
 
 namespace ear {
 namespace plugin {
@@ -9,6 +10,7 @@ SceneGainsCalculator::SceneGainsCalculator(ear::Layout outputLayout,
                                            int inputChannelCount)
     : objectCalculator_{outputLayout}, directSpeakersCalculator_{outputLayout} {
   resize(outputLayout, static_cast<std::size_t>(inputChannelCount));
+  allActiveIds.reserve(inputChannelCount);;
 }
 
 bool SceneGainsCalculator::update(proto::SceneStore store) {
@@ -30,8 +32,10 @@ bool SceneGainsCalculator::update(proto::SceneStore store) {
                 diffuse_[routing.track + i].end(), 0.0f);
     }
   }
+
   for (const auto& item : store.items()) {
-    if (item.changed()) {
+    bool newItem = std::find(allActiveIds.begin(), allActiveIds.end(), item.connection_id()) == allActiveIds.end();
+    if (newItem || item.changed()) {
       if (item.has_ds_metadata()) {
         auto earMetadata =
             EpsToEarMetadataConverter::convert(item.ds_metadata());
@@ -64,6 +68,13 @@ bool SceneGainsCalculator::update(proto::SceneStore store) {
       }
     }
   }
+
+  // Used for setting the newItem flag next time around
+  allActiveIds.clear();
+  for(const auto& item : store.items()) {
+    allActiveIds.push_back(item.connection_id());
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Found some more issues uncovered by fixing #99 (PR #111 )

-Some input plugin parameters are not setting the "changed" flag to true, meaning they are not affecting the audible output because the monitoring plugins ignore the metadata.

- New monitoring plugins initially do not render existing inputs correctly until a parameter is changed. This is because the "changed" flag in the metadata from these input is false and so the monitoring plugin does not process it. However, the monitoring plugin must still process it if it has never seen metadata for a particular input before, because it needs to set the correct initial state for that input.

These issues were initially hidden by #99, because the changed flag was never reset, and so ALL metadata was reported as changed and ALL metadata messages were therefore processed.