### PR TITLE
Metadata sender refactor

### DIFF
--- a/ear-production-suite-plugins/lib/CMakeLists.txt
+++ b/ear-production-suite-plugins/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ protobuf_generate_cpp(EAR_PROTO_SRC EAR_PROTO_HDR ${EAR_PROTO_INPUT})
 
 add_library(ear-plugin-base STATIC
   src/communication/commands.cpp
+  src/communication/metadata_sender.cpp
   src/communication/direct_speakers_metadata_sender.cpp
   src/communication/input_control_connection.cpp
   src/communication/monitoring_control_connection.cpp
@@ -43,6 +44,7 @@ add_library(ear-plugin-base STATIC
 set(EAR_BASE_HEADERS		
 	include/communication/commands.hpp
 	include/communication/common_types.hpp
+	include/communication/metadata_sender.hpp
 	include/communication/direct_speakers_metadata_sender.hpp
 	include/communication/input_control_connection.hpp
 	include/communication/message_buffer.hpp
@@ -125,7 +127,7 @@ target_include_directories(ear-plugin-base PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>  # protobuf
 	${EPS_SHARED_DIR}
 )
-target_compile_features(ear-plugin-base PUBLIC cxx_std_14)
+target_compile_features(ear-plugin-base PUBLIC cxx_std_17)
 target_compile_definitions(ear-plugin-base PUBLIC BOOST_UUID_FORCE_AUTO_LINK)
 set_target_properties(ear-plugin-base PROPERTIES POSITION_INDEPENDENT_CODE ON CXX_EXTENSIONS OFF)
 set_target_properties(ear-plugin-base PROPERTIES FOLDER ${IDE_FOLDER_PLUGINS})

--- a/ear-production-suite-plugins/lib/include/communication/data_wrapper.hpp
+++ b/ear-production-suite-plugins/lib/include/communication/data_wrapper.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <functional>
+#include <mutex>
+#include "message_buffer.hpp"
+#include "input_item_metadata.pb.h"
+
+namespace ear::plugin::communication {
+
+class DataWrapper {
+ public:
+  explicit DataWrapper(std::function<void(proto::InputItemMetadata*)> init) {
+    writeAccess(init);
+  }
+
+  template <typename FunctionT>
+  void writeAccess(FunctionT&& accessor) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    data_.set_changed(true);
+    std::invoke(accessor, &data_);
+  }
+
+  template <typename FunctionT>
+  void readAccess(FunctionT&& accessor) {
+    std::lock_guard<std::mutex> lock{mutex_};
+    auto const& data{data_};
+    std::invoke(accessor, data);
+  }
+
+  MessageBuffer prepareMessage() {
+    std::lock_guard<std::mutex> lock{mutex_};
+    MessageBuffer buffer = allocBuffer(data_.ByteSizeLong());
+    data_.SerializeToArray(buffer.data(), buffer.size());
+    data_.set_changed(false);
+    return buffer;
+  }
+
+ private:
+  proto::InputItemMetadata data_;
+  std::mutex mutex_;
+};
+}

--- a/ear-production-suite-plugins/lib/include/communication/direct_speakers_metadata_sender.hpp
+++ b/ear-production-suite-plugins/lib/include/communication/direct_speakers_metadata_sender.hpp
@@ -1,15 +1,10 @@
 #pragma once
 
-#include "common_types.hpp"
-#include "message_buffer.hpp"
-#include "nng-cpp/nng.hpp"
-#include "log.hpp"
-#include "input_item_metadata.pb.h"
-#include <boost/optional.hpp>
 #include <string>
 #include <chrono>
-#include <mutex>
-#include <atomic>
+#include "metadata_sender.hpp"
+#include "data_wrapper.hpp"
+#include "log.hpp"
 
 namespace ear {
 namespace plugin {
@@ -19,13 +14,9 @@ class DirectSpeakersMetadataSender {
  public:
   DirectSpeakersMetadataSender(
       std::shared_ptr<spdlog::logger> logger = nullptr);
-  ~DirectSpeakersMetadataSender();
-
   void logger(std::shared_ptr<spdlog::logger> logger);
-
   void connect(const std::string& endpoint, ConnectionId connectionId);
   void disconnect();
-
   void triggerSend();
 
   void routing(int32_t value);
@@ -33,31 +24,16 @@ class DirectSpeakersMetadataSender {
   void colour(int value);
   void speakerSetupIndex(int value);
 
-  ConnectionId getConnectionId() { return connectionId_; }
+  ConnectionId getConnectionId() { return sender_.connectionId(); }
 
  private:
-  void sendMetadata();
-  void startTimer();
-  MessageBuffer prepareMessage();
-  void handleTimeout(std::error_code ec);
   template<typename FunctionT>
   void setData(FunctionT&& set) {
-    std::lock_guard<std::mutex> dataLock{dataMutex_};
-    data_.set_changed(true);
-    set(&data_);
+    data_.writeAccess([set](auto data) { std::invoke(set, data); });
   }
   std::shared_ptr<spdlog::logger> logger_;
-  nng::PushSocket socket_;
-  nng::AsyncIO timer_;
-  nng::Dialer dialer_;
-  std::mutex dataMutex_;
-  std::mutex timeoutMutex_;
-  std::mutex sendMutex_;
-  proto::InputItemMetadata data_;
-  ConnectionId connectionId_;
-  std::chrono::system_clock::time_point lastSendTimestamp_;
-  std::chrono::milliseconds maxSendInterval_;
-  std::atomic<bool> timerRunning{false};
+  DataWrapper data_;
+  MetadataSender sender_;
 };
 
 }  // namespace communication

--- a/ear-production-suite-plugins/lib/include/communication/metadata_sender.hpp
+++ b/ear-production-suite-plugins/lib/include/communication/metadata_sender.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <chrono>
+#include <mutex>
+#include <atomic>
+#include <functional>
+#include <string>
+#include <system_error>
+#include "common_types.hpp"
+#include "log.hpp"
+#include "message_buffer.hpp"
+#include "data_wrapper.hpp"
+#include "nng-cpp/nng.hpp"
+
+namespace ear::plugin::communication {
+
+class MetadataSender {
+ public:
+  explicit MetadataSender(DataWrapper& data,
+                          std::shared_ptr<spdlog::logger> logger = nullptr);
+  ~MetadataSender();
+  void connect(const std::string& endpoint,
+               ConnectionId id);
+  ConnectionId connectionId();
+  void disconnect();
+  void triggerSend();
+  void logger(std::shared_ptr<spdlog::logger> logger);
+ private:
+  void startTimer();
+  void handleTimeout(std::error_code ec);
+  DataWrapper& data_;
+  std::shared_ptr<spdlog::logger> logger_;
+  nng::PushSocket socket_;
+  nng::AsyncIO timer_;
+  nng::Dialer dialer_;
+  std::mutex timeoutMutex_;
+  std::mutex sendMutex_;
+  ConnectionId connectionId_;
+  std::chrono::system_clock::time_point lastSendTimestamp_;
+  std::chrono::milliseconds maxSendInterval_;
+  std::atomic<bool> timerRunning{false};
+};
+}

--- a/ear-production-suite-plugins/lib/include/communication/object_metadata_sender.hpp
+++ b/ear-production-suite-plugins/lib/include/communication/object_metadata_sender.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
 #include "common_types.hpp"
+#include "data_wrapper.hpp"
+#include "metadata_sender.hpp"
 #include "message_buffer.hpp"
-#include "nng-cpp/nng.hpp"
 #include "log.hpp"
 #include "input_item_metadata.pb.h"
-#include <boost/optional.hpp>
 #include <string>
-#include <chrono>
-#include <mutex>
-#include <atomic>
 
 namespace ear {
 namespace plugin {
@@ -18,13 +15,10 @@ namespace communication {
 class ObjectMetadataSender {
  public:
   ObjectMetadataSender(std::shared_ptr<spdlog::logger> logger = nullptr);
-  ~ObjectMetadataSender();
 
   void logger(std::shared_ptr<spdlog::logger> logger);
-
   void connect(const std::string& endpoint, ConnectionId connectionId);
   void disconnect();
-
   void triggerSend();
 
   void routing(int32_t value);
@@ -43,40 +37,23 @@ class ObjectMetadataSender {
   void factor(float);
   void range(float);
 
-  ConnectionId getConnectionId() { return connectionId_; }
+  ConnectionId getConnectionId() { return sender_.connectionId(); }
 
  private:
-  void sendMetadata();
-  void startTimer();
-  MessageBuffer prepareMessage();
-  void handleTimeout(std::error_code ec);
   template<typename FunctionT>
   void setData(FunctionT&& set) {
-    // send as pointer so can't accidentally copy based on FunctionT
-    // and to match setObjectData
-    std::lock_guard<std::mutex> lock(dataMutex_);
-    data_.set_changed(true);
-    set(&data_);
+    data_.writeAccess([set](auto data) {
+      std::invoke(set, data);
+    });
   }
   template<typename FunctionT>
   void setObjectData(FunctionT&& set) {
-    std::lock_guard<std::mutex> lock(dataMutex_);
-    data_.set_changed(true);
-    set(data_.mutable_obj_metadata());
+    data_.writeAccess([set](auto data) {
+      std::invoke(set, data->mutable_obj_metadata());
+    });
   }
-
-  std::shared_ptr<spdlog::logger> logger_;
-  nng::PushSocket socket_;
-  nng::AsyncIO timer_;
-  nng::Dialer dialer_;
-  std::mutex dataMutex_;
-  std::mutex timeoutMutex_;
-  std::mutex sendMutex_;
-  proto::InputItemMetadata data_;
-  ConnectionId connectionId_;
-  std::chrono::system_clock::time_point lastSendTimestamp_;
-  std::chrono::milliseconds maxSendInterval_;
-  std::atomic_bool timerRunning{false};
+  DataWrapper data_;
+  MetadataSender sender_;
 };
 
 }  // namespace communication

--- a/ear-production-suite-plugins/lib/src/communication/direct_speakers_metadata_sender.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/direct_speakers_metadata_sender.cpp
@@ -1,114 +1,30 @@
 #include "communication/direct_speakers_metadata_sender.hpp"
 #include "helper/protobuf_utilities.hpp"
 
-using namespace std::chrono_literals;
-
-namespace ear {
-namespace plugin {
-
-namespace communication {
+namespace ear::plugin::communication {
 
 DirectSpeakersMetadataSender::DirectSpeakersMetadataSender(
     std::shared_ptr<spdlog::logger> logger)
-    : logger_(logger), maxSendInterval_(100ms) {
-  lastSendTimestamp_ = std::chrono::system_clock::now();
-  data_.set_allocated_ds_metadata(new proto::DirectSpeakersTypeMetadata{});
-}
-
-DirectSpeakersMetadataSender::~DirectSpeakersMetadataSender() {
-  timer_.stop();
-  timer_.wait();
-}
+    : logger_(std::move(logger)),
+      data_{[](auto data) {
+        data->set_allocated_ds_metadata(
+            new proto::DirectSpeakersTypeMetadata{});
+      }},
+      sender_(data_, logger_) {}
 
 void DirectSpeakersMetadataSender::logger(
     std::shared_ptr<spdlog::logger> logger) {
-  logger_ = logger;
+  sender_.logger(std::move(logger));
 }
 
 void DirectSpeakersMetadataSender::connect(const std::string& endpoint,
                                            ConnectionId id) {
-  std::lock_guard<std::mutex> lock(dataMutex_);
-  connectionId_ = id;
-  data_.set_connection_id(connectionId_.string());
-  // set data changed flag to trigger/ sending metadata
-  // to the scene master when the connection has been established,
-  // even if the data hasn't ""changed"" from the object input point of view.
-  data_.set_changed(true);
-  EAR_LOGGER_DEBUG(logger_, "Connecting metadata stream to {}", endpoint);
-  dialer_ = socket_.createDialer(endpoint.c_str());
-  dialer_.start();
-  EAR_LOGGER_DEBUG(logger_, "Metadata stream connected", endpoint);
-  startTimer();
+  sender_.connect(endpoint, id);
 }
 
-MessageBuffer DirectSpeakersMetadataSender::prepareMessage() {
-  std::lock_guard<std::mutex> lock(dataMutex_);
-  MessageBuffer buffer = allocBuffer(data_.ByteSizeLong());
-  data_.SerializeToArray(buffer.data(), buffer.size());
-  data_.set_changed(false);
-  return buffer;
-}
+void DirectSpeakersMetadataSender::disconnect() { sender_.disconnect(); }
 
-void DirectSpeakersMetadataSender::disconnect() {
-  timer_.cancel();
-  timer_.wait();
-  socket_.asyncCancel();
-  socket_.asyncWait();
-  dialer_.close();
-  connectionId_ = ConnectionId{};
-  socket_ = nng::PushSocket{};
-}
-
-void DirectSpeakersMetadataSender::triggerSend() { sendMetadata(); }
-
-void DirectSpeakersMetadataSender::sendMetadata() {
-  std::lock_guard<std::mutex> lock(sendMutex_);
-  socket_.asyncWait();
-  if (!connectionId_.isValid()) {
-    return;
-  }
-  auto msg = prepareMessage();
-  socket_.asyncSend(
-      msg, [this](std::error_code ec, const nng::Message& ignored) {
-        if (!ec) {
-          std::lock_guard<std::mutex> lock(timeoutMutex_);
-          lastSendTimestamp_ = std::chrono::system_clock::now();
-        } else {
-          {
-            std::lock_guard<std::mutex> dataLock(dataMutex_);
-            data_.set_changed(true);
-          }
-          EAR_LOGGER_WARN(logger_, "Metadata sending failed: {}", ec.message());
-        }
-      });
-}
-
-void DirectSpeakersMetadataSender::startTimer() {
-  if (maxSendInterval_ > 0ms) {
-    bool expected{false};
-    if(timerRunning.compare_exchange_strong(expected, true)) {
-      timer_.sleep(maxSendInterval_,
-                   std::bind(&DirectSpeakersMetadataSender::handleTimeout, this,
-                             nng::placeholders::ErrorCode));
-    }
-  }
-}
-
-void DirectSpeakersMetadataSender::handleTimeout(std::error_code ec) {
-  timerRunning.store(false);
-  if (!ec) {
-    auto now = std::chrono::system_clock::now();
-    std::chrono::system_clock::duration deltaT{0};
-    {
-      std::lock_guard<std::mutex> lock(timeoutMutex_);
-      deltaT = now - lastSendTimestamp_;
-    }
-    if (deltaT > maxSendInterval_) {
-      sendMetadata();
-    }
-    startTimer();
-  }
-}
+void DirectSpeakersMetadataSender::triggerSend() { sender_.triggerSend(); }
 
 void DirectSpeakersMetadataSender::routing(int32_t value) {
   setData([value](auto data) { data->set_routing(value); });
@@ -126,6 +42,4 @@ void DirectSpeakersMetadataSender::speakerSetupIndex(int value) {
   });
 }
 
-}  // namespace communication
-}  // namespace plugin
-}  // namespace ear
+}  // namespace ear::plugin::communication

--- a/ear-production-suite-plugins/lib/src/communication/metadata_sender.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/metadata_sender.cpp
@@ -1,0 +1,98 @@
+#include "communication/metadata_sender.hpp"
+namespace ear {
+namespace plugin {
+namespace communication {
+
+MetadataSender::MetadataSender(
+    DataWrapper& data,
+    std::shared_ptr<spdlog::logger> logger)
+    : data_{data},
+      logger_{std::move(logger)},
+      maxSendInterval_{std::chrono::milliseconds(100)},
+      lastSendTimestamp_{std::chrono::system_clock::now()} {}
+
+MetadataSender::~MetadataSender() {
+  timer_.stop();
+  timer_.wait();
+}
+
+ConnectionId MetadataSender::connectionId() { return connectionId_; }
+
+void MetadataSender::disconnect() {
+  timer_.cancel();
+  timer_.wait();
+  socket_.asyncCancel();
+  socket_.asyncWait();
+  dialer_.close();
+  connectionId_ = ConnectionId{};
+  socket_ = nng::PushSocket{};
+}
+
+void MetadataSender::triggerSend() {
+  std::lock_guard<std::mutex> lock(sendMutex_);
+  socket_.asyncWait();
+  if (!connectionId_.isValid()) {
+    return;
+  }
+  auto msg = data_.prepareMessage();
+  socket_.asyncSend(
+      msg, [this](std::error_code ec, const nng::Message& ignored) {
+        if (!ec) {
+          std::lock_guard<std::mutex> lock(timeoutMutex_);
+          lastSendTimestamp_ = std::chrono::system_clock::now();
+        } else {
+          // this sets changed flag
+          data_.writeAccess([](auto){});
+          EAR_LOGGER_WARN(logger_, "Metadata sending failed: {}", ec.message());
+        }
+      });
+}
+
+void MetadataSender::startTimer() {
+  using namespace std::chrono_literals;
+  if (maxSendInterval_ > 0ms) {
+    bool expected{false};
+    if (timerRunning.compare_exchange_strong(expected, true)) {
+      timer_.sleep(maxSendInterval_,
+                   std::bind(&MetadataSender::handleTimeout, this,
+                             nng::placeholders::ErrorCode));
+    }
+  }
+}
+
+void MetadataSender::handleTimeout(std::error_code ec) {
+  timerRunning.store(false);
+  if (!ec) {
+    auto now = std::chrono::system_clock::now();
+    std::chrono::system_clock::duration deltaT{0};
+    {
+      std::lock_guard<std::mutex> lock(timeoutMutex_);
+      deltaT = now - lastSendTimestamp_;
+    }
+    if (deltaT > maxSendInterval_) {
+      triggerSend();
+    }
+    startTimer();
+  }
+}
+void MetadataSender::logger(std::shared_ptr<spdlog::logger> logger) {
+  logger_ = std::move(logger);
+}
+
+void MetadataSender::connect(const std::string& endpoint, ConnectionId id) {
+  data_.writeAccess([this, &id, &endpoint](auto data) {
+    connectionId_ = id;
+    data->set_connection_id(connectionId_.string());
+    // set data changed flag to trigger/ sending metadata
+    // to the scene master when the connection has been established,
+    // even if the data hasn't ""changed"" from the object input point of view.
+    EAR_LOGGER_DEBUG(logger_, "Connecting metadata stream to {}", endpoint);
+    dialer_ = socket_.createDialer(endpoint.c_str());
+    dialer_.start();
+    EAR_LOGGER_DEBUG(logger_, "Metadata stream connected", endpoint);
+    startTimer();
+  });
+}
+}  // namespace communication
+}  // namespace plugin
+}  // namespace ear

--- a/ear-production-suite-plugins/lib/src/communication/object_metadata_sender.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/object_metadata_sender.cpp
@@ -9,104 +9,26 @@ namespace communication {
 
 ObjectMetadataSender::ObjectMetadataSender(
     std::shared_ptr<spdlog::logger> logger)
-    : logger_(logger), maxSendInterval_(100ms) {
-  lastSendTimestamp_ = std::chrono::system_clock::now();
-  data_.set_allocated_obj_metadata(new proto::ObjectsTypeMetadata{});
-}
-
-ObjectMetadataSender::~ObjectMetadataSender() {
-  timer_.stop();
-  timer_.wait();
+    : data_([](auto data) {
+        data->set_allocated_obj_metadata(new proto::ObjectsTypeMetadata{});
+      }),
+      sender_(data_, std::move(logger)) {
 }
 
 void ObjectMetadataSender::logger(std::shared_ptr<spdlog::logger> logger) {
-  logger_ = logger;
+  sender_.logger(std::move(logger));
 }
 
 void ObjectMetadataSender::connect(const std::string& endpoint,
                                    ConnectionId id) {
-  std::lock_guard<std::mutex> lock(dataMutex_);
-  connectionId_ = id;
-  data_.set_connection_id(connectionId_.string());
-  // set data changed flag to trigger/ sending metadata
-  // to the scene master when the connection has been established,
-  // even if the data hasn't ""changed"" from the object input point of view.
-  data_.set_changed(true);
-  EAR_LOGGER_DEBUG(logger_, "Connecting metadata stream to {}", endpoint);
-  dialer_ = socket_.createDialer(endpoint.c_str());
-  dialer_.start();
-  EAR_LOGGER_DEBUG(logger_, "Metadata stream connected", endpoint);
-  startTimer();
-}
-
-MessageBuffer ObjectMetadataSender::prepareMessage() {
-  std::lock_guard<std::mutex> lock(dataMutex_);
-  MessageBuffer buffer = allocBuffer(data_.ByteSizeLong());
-  data_.SerializeToArray(buffer.data(), buffer.size());
-  data_.set_changed(false);
-  return buffer;
+  sender_.connect(endpoint, std::move(id));
 }
 
 void ObjectMetadataSender::disconnect() {
-  timer_.cancel();
-  timer_.wait();
-  socket_.asyncCancel();
-  socket_.asyncWait();
-  dialer_.close();
-  connectionId_ = ConnectionId{};
-  socket_ = nng::PushSocket{};
+  sender_.disconnect();
 }
 
-void ObjectMetadataSender::triggerSend() { sendMetadata(); }
-
-void ObjectMetadataSender::sendMetadata() {
-  std::lock_guard<std::mutex> lock(sendMutex_);
-  socket_.asyncWait();
-  if (!connectionId_.isValid()) {
-    return;
-  }
-  auto msg = prepareMessage();
-  socket_.asyncSend(
-      msg, [this](std::error_code ec, const nng::Message& ignored) {
-        if (!ec) {
-          std::lock_guard<std::mutex> lock(timeoutMutex_);
-          lastSendTimestamp_ = std::chrono::system_clock::now();
-        } else {
-          {
-            std::lock_guard<std::mutex> dataLock(dataMutex_);
-            data_.set_changed(true);
-          }
-          EAR_LOGGER_WARN(logger_, "Metadata sending failed: {}", ec.message());
-        }
-      });
-}
-
-void ObjectMetadataSender::startTimer() {
-  if (maxSendInterval_ > 0ms) {
-    bool expected{false};
-    if(timerRunning.compare_exchange_strong(expected, true)) {
-      timer_.sleep(maxSendInterval_,
-                   std::bind(&ObjectMetadataSender::handleTimeout, this,
-                             nng::placeholders::ErrorCode));
-    }
-  }
-}
-
-void ObjectMetadataSender::handleTimeout(std::error_code ec) {
-  timerRunning.store(false);
-  if (!ec) {
-    auto now = std::chrono::system_clock::now();
-    std::chrono::system_clock::duration deltaT{0};
-    {
-      std::lock_guard<std::mutex> lock(timeoutMutex_);
-      deltaT = now - lastSendTimestamp_;
-    }
-    if (deltaT > maxSendInterval_) {
-      sendMetadata();
-    }
-    startTimer();
-  }
-}
+void ObjectMetadataSender::triggerSend() { sender_.triggerSend(); }
 
 void ObjectMetadataSender::name(const std::string& value) {
   setData([value](auto data) { data->set_name(value); });


### PR DESCRIPTION
Builds on #135 to factor out common functionality between DirectSpeakersMetadataSender and ObjectsMetadataSender into DataWrapper and MetadataSender