### PR TITLE
Set InputItemMetadata changed when routings clash or are resolved

### DIFF
--- a/ear-production-suite-plugins/lib/CMakeLists.txt
+++ b/ear-production-suite-plugins/lib/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(ear-plugin-base STATIC
   src/nng-cpp/error_handling.cpp
   src/object_backend.cpp
   src/programme_types.cpp
+  src/routing_overlap.cpp
   src/scene_backend.cpp
   src/scene_gains_calculator.cpp
   src/programme_store_adm_populator.cpp
@@ -91,6 +92,7 @@ set(EAR_BASE_HEADERS
 	include/programme_store_adm_serializer.hpp
 	include/programme_types.hpp
 	include/proto_printers.hpp
+	include/routing_overlap.hpp
 	include/scene_backend.hpp
 	include/scene_gains_calculator.hpp
 	include/ui/direct_speakers_frontend_backend_connector.hpp

--- a/ear-production-suite-plugins/lib/include/routing_overlap.hpp
+++ b/ear-production-suite-plugins/lib/include/routing_overlap.hpp
@@ -1,0 +1,13 @@
+#pragma once
+#include <string>
+#include <set>
+#include "scene_store.pb.h"
+
+namespace ear {
+namespace plugin {
+std::set<std::string> getOverlapIds(proto::SceneStore const& store);
+void flagChangedOverlaps(std::set<std::string> const& previousOverlaps,
+                         std::set<std::string> const& currentOverlaps,
+                         proto::SceneStore& store);
+}  // namespace plugin
+}  // namespace ear

--- a/ear-production-suite-plugins/lib/include/scene_backend.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_backend.hpp
@@ -83,6 +83,7 @@ class SceneBackend {
   nng::PubSocket metadataSender_;
   std::mutex storeMutex_;
   std::set<communication::ConnectionId> previousScene_;
+  std::set<std::string> overlappingIds_;
 };
 
 }  // namespace plugin

--- a/ear-production-suite-plugins/lib/src/routing_overlap.cpp
+++ b/ear-production-suite-plugins/lib/src/routing_overlap.cpp
@@ -1,0 +1,162 @@
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+#include <unordered_map>
+#include <vector>
+
+#include "routing_overlap.hpp"
+namespace ear {
+namespace plugin {
+
+namespace {
+// represet the routing of an input plugin
+struct Routing {
+  int startChannel;
+  int size;
+};
+
+struct Overlap {
+  std::size_t channel;
+  std::unordered_set<std::string> ids;
+};
+
+// indices of returned vector are channel numbers
+// for each channel, determine set of input IDs routed there
+std::vector<std::unordered_set<std::string>> channelAllocation(
+    const std::unordered_map<std::string, Routing>& routings) {
+  std::vector<std::unordered_set<std::string>> allocation;
+  for (auto const& [id, route] : routings) {
+    // -1 routing used to represent unset state in plugin
+    // ignore those as should never be rendered
+    if (route.startChannel >= 0) {
+      auto endIndex = route.startChannel + route.size;
+      if (endIndex > allocation.size()) {
+        allocation.resize(endIndex);
+      }
+      for (auto i = route.startChannel; i != endIndex; ++i) {
+        allocation[i].insert(id);
+      }
+    }
+  }
+  return allocation;
+}
+
+// more than one ID per channel == overlap
+bool hasOverlap(const std::unordered_set<std::string>& channelIds) {
+  return channelIds.size() > 1;
+}
+
+// extract overlapping routes from vector of all alocations
+std::vector<Overlap> getOverlaps(
+    const std::unordered_map<std::string, Routing>& routings) {
+  auto allocations = channelAllocation(routings);
+  std::vector<Overlap> overlaps;
+  for (std::size_t i = 0; i != allocations.size(); ++i) {
+    if (hasOverlap(allocations[i])) {
+      overlaps.push_back({i, allocations[i]});
+    }
+  }
+  return overlaps;
+}
+
+// determine routings from scene store. 1 channel per ID for objects, n channels
+// for directspeakers
+// TODO update for HOA
+std::unordered_map<std::string, Routing> getRoutings(
+    proto::SceneStore const& store) {
+  std::unordered_map<std::string, Routing> routings;
+  auto const& items = store.items();
+  for (auto const& item : items) {
+    auto routeWidth =
+        item.has_ds_metadata() ? item.ds_metadata().speakers().size() : 1;
+    routings.emplace(item.connection_id(), Routing{item.routing(), routeWidth});
+  }
+  return routings;
+}
+
+std::vector<Overlap> getOverlaps(const proto::SceneStore& store) {
+  return getOverlaps(getRoutings(store));
+}
+
+// Possibly redundant now, added this to cache store id lookup when was
+// doing this often in previous iteration, we still do it more than once
+// so maybe worthwhile.
+class ItemCache {
+ public:
+  explicit ItemCache(proto::SceneStore& store) : store{store} {}
+  proto::MonitoringItemMetadata* get(std::string const& connectionId) {
+    auto items = store.mutable_items();
+    if (auto it = cache.find(connectionId); it == cache.end()) {
+      cache[connectionId] =
+          &(*std::find_if(items->begin(), items->end(),
+                          [connectionId](proto::MonitoringItemMetadata& item) {
+                            return item.connection_id() == connectionId;
+                          }));
+    }
+    return cache[connectionId];
+  }
+
+ private:
+  proto::SceneStore& store;
+  std::map<std::string, proto::MonitoringItemMetadata*> cache;
+};
+
+// if any of the items with ids in input set are flagged as changed, all should
+// be updated in case that change was the routing. This could probably be
+// improved
+void setOverlapsAsChanged(std::set<std::string> const& overlappingIds,
+                          proto::SceneStore& store) {
+  ItemCache items{store};
+  if (std::any_of(overlappingIds.begin(), overlappingIds.end(),
+                  [&items](std::string const& id) {
+                    return items.get(id)->changed();
+                  })) {
+    std::for_each(
+        overlappingIds.begin(), overlappingIds.end(),
+        [&items](std::string const& id) { items.get(id)->set_changed(true); });
+  }
+}
+}  // namespace
+
+// returns the set of connection IDs in the store that have overlapping routings
+// may not all belong to same overlap set. (e.g. 4 inputs with 2 distinct
+// overlaps)
+std::set<std::string> getOverlapIds(const proto::SceneStore& store) {
+  auto overlaps = getOverlaps(store);
+  std::set<std::string> overlapIds;
+  auto inserter = std::inserter(overlapIds, overlapIds.end());
+  for (auto const& overlap : overlaps) {
+    std::copy(overlap.ids.begin(), overlap.ids.end(), inserter);
+  }
+  return overlapIds;
+}
+
+// A blunt solution - a change in the set of overlapping ids flags all items
+// with IDs in the previous and current overlap sets as changed
+void flagChangedOverlaps(const std::set<std::string>& previousOverlaps,
+                         const std::set<std::string>& currentOverlaps,
+                         proto::SceneStore& store) {
+  std::set<std::string> allOverlaps = currentOverlaps;
+  // mark items that have had their routing resolved as changed
+  // (potentially by a different item changing routing)
+  // this is so the renderer will recalculate gain.
+  for (auto const& overlap : previousOverlaps) {
+    auto [it, success] = allOverlaps.insert(overlap);
+    if (success) {
+      auto items = store.mutable_items();
+      auto const& id = *it;
+      auto itemIt =
+          std::find_if(items->begin(), items->end(),
+                       [&id](proto::MonitoringItemMetadata const& data) {
+                         return data.connection_id() == id;
+                       });
+      if (itemIt != items->end()) {
+        itemIt->set_changed(true);
+      }
+    }
+  }
+  setOverlapsAsChanged(allOverlaps, store);
+}
+
+}  // namespace plugin
+}  // namespace ear

--- a/ear-production-suite-plugins/lib/src/scene_backend.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_backend.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <google/protobuf/util/message_differencer.h>
 #include <cassert>
+#include "routing_overlap.hpp"
 
 using std::placeholders::_1;
 using std::placeholders::_2;
@@ -61,7 +62,7 @@ void SceneBackend::triggerMetadataSend() {
 void SceneBackend::setup() {
   try {
     connectionManager_.setEventHandler(
-        std ::bind(&SceneBackend::onConnectionEvent, this, _1, _2));
+        std::bind(&SceneBackend::onConnectionEvent, this, _1, _2));
   } catch (const std::runtime_error& e) {
     EAR_LOGGER_ERROR(logger_, "Scene Master: Failed to set event handler: {}",
                      e.what());
@@ -151,6 +152,12 @@ void SceneBackend::updateSceneStore() {
       addElementToSceneStore(element);
     }
   }
+
+  auto overlaps = getOverlapIds(sceneStore_);
+  if(overlappingIds_ != overlaps) {
+    flagChangedOverlaps(overlappingIds_, overlaps, sceneStore_);
+  }
+  overlappingIds_ = overlaps;
 
   previousScene_.clear();
   for (auto const& item : sceneStore_.items()) {


### PR DESCRIPTION
fixes #141

### Problem cause
The input plugins now properly flag whether metadata is changed. Updates to rendering / output gains only occur when metadata changes. In addition, the rendering plugin expects only one input per channel when calculating gains.

Routing clashes introduce a dependency between inputs, if A and B clash, and A is changed to resolve the clash, B is also affected as it needs it's gain recalculating. The renderer doesn't 'know' as B's metadata has not changed.

When there are overlapping inputs, rendering is incorrect (expected), however when this is resolved, only one of the inputs involved in the clash will be marked as changed (the one whose routing was altered) so the other can continue to be rendered incorrectly.

### Solution
This fix keeps track of clashes in the Scene plugin. It causes all inputs that currently clash or clashed during the last update to be flagged as changed whenever any other input in the clash set has been flagged as changed. 

I suspect this is a bit crude.

### Approach
I could have implemented the fix in the renderer or the scene, but we've talked previously about indicating clashes in the scene plugin so thought it might be best in there.

Implemented as free functions primarily as we're directly using the protobuf generated proto::SceneStore inside the Scene plugin. This means we can't add extra members to it. I could have wrapped the SceneStore and added methods to the wrapper, but I remember us deliberately taking out a layer here before so I was a bit hesitant. 

I did most of this with a cold / fuzzy head so would really appreciate feedback, if something looks silly it probably is.