### PR TITLE
Search for arm64 plugins during init as well as x86_64

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/pluginregistry.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginregistry.cpp
@@ -15,28 +15,34 @@ void admplug::PluginRegistry::repopulateInstalledPlugins(bool warnOnFailure, con
 {
     installedPlugins.clear();
 
-    // First open and read the vst file - reaper-vstplugins64.ini
-    auto vstIniPath = std::string{api.GetResourcePath()};
-    vstIniPath += (file::dirChar() + std::string{"reaper-vstplugins64.ini"});
-    std::ifstream ifs(vstIniPath.c_str());
+    static const std::vector<std::string> iniFiles{std::string{"reaper-vstplugins64.ini"},
+                                                std::string{"reaper-vstplugins_arm64.ini"}};
+    auto vstIniPath = std::string{api.GetResourcePath()}.append(file::dirChar());
+    bool fileFound{false};
+    for(auto const&fileName : iniFiles) {
+      std::string filePath{vstIniPath + fileName};
+      std::ifstream ifs{filePath};
 
-    // Next, parse the file... CSV, 3 part; filename + "=" + uid??, uid???, name (e.g,  VISR SceneMasterVST (visr) (64ch)) - we might need to do some lazy matching on that... (e.g, end bit probably isn't expected)
-    if (ifs.is_open()) {
+      // Next, parse the fileName... CSV, 3 part; filename + "=" + uid??, uid???, name (e.g,  VISR SceneMasterVST (visr) (64ch)) - we might need to do some lazy matching on that... (e.g, end bit probably isn't expected)
+      if (ifs) {
+        fileFound = true;
         std::string line;
         while (std::getline(ifs, line)) {
-            auto startOffset = line.find("=");
-            if (startOffset == std::string::npos) continue;
-            startOffset = line.find(",", startOffset + 1);
-            if (startOffset == std::string::npos) continue;
-            startOffset = line.find(",", startOffset + 1);
-            if (startOffset == std::string::npos) continue;
-            installedPlugins.push_back(line.substr(startOffset + 1));
+          auto startOffset = line.find('=');
+          if (startOffset == std::string::npos)
+            continue;
+          startOffset = line.find(',', startOffset + 1);
+          if (startOffset == std::string::npos)
+            continue;
+          startOffset = line.find(',', startOffset + 1);
+          if (startOffset == std::string::npos)
+            continue;
+          installedPlugins.push_back(line.substr(startOffset + 1));
         }
-        ifs.close();
+      }
     }
-    else if(warnOnFailure){
+    if(warnOnFailure && !fileFound){
         std::string msg("Can not open plugin cache file!\n\n");
-        msg += vstIniPath;
         const char* title = "ADM Extension";
 #ifdef WIN32
         // Windows version of Reaper locks up if you try show a message box during splash


### PR DESCRIPTION
The extension disables importing from a plugin suite with missing plugins, but
it was only searching for plugins via reaper-vstplugins64.ini. arm64 plugins are catalogued
in reaper-vstplugins_arm64.ini so were never found. This commit modifies the behaviour to search
both files.

Also prevents a warning about a missing ini file being shown when REAPER is launched in debug mode.