### PR TITLE
Ensure correct point ordering

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/admextraction.cpp
+++ b/reaper-adm-extension/src/reaper_adm/admextraction.cpp
@@ -86,3 +86,14 @@ std::vector<admplug::AutomationPoint> admplug::detail::simplify(const std::vecto
     }
     return filtered;
 }
+
+void admplug::detail::fixEffectiveTimeOverlaps(std::vector<AutomationPoint> &points)
+{
+    // This function assumes points are already sorted by start time
+    // Effective time overlap can occur when a blocks rtime + duration exceeds the start time of the next block
+    for(size_t i = 0; i < (points.size() - 1); i++) {
+        if(points[i].effectiveTimeNs() > points[i + 1].timeNs()) {
+            points[i].setDurationFromEffectiveTimeNs(points[i + 1].timeNs());
+        }
+    }
+}

--- a/reaper-adm-extension/src/reaper_adm/admextraction.h
+++ b/reaper-adm-extension/src/reaper_adm/admextraction.h
@@ -8,8 +8,8 @@
 
 namespace {
     bool pointsTimeSorter(admplug::AutomationPoint &pointA, admplug::AutomationPoint &pointB) {
-        if(pointA.time() == pointB.time()) return pointA.duration() < pointB.duration();
-        return pointA.time() < pointB.time();
+        if(pointA.timeNs() == pointB.timeNs()) return pointA.durationNs() < pointB.durationNs();
+        return pointA.timeNs() < pointB.timeNs();
     }
 }
 
@@ -262,6 +262,7 @@ std::optional<AutomationPoint> getSphericalPoint(Parameter const& param, adm::Au
 }
 
 std::vector<AutomationPoint> simplify(std::vector<AutomationPoint> const& points);
+void fixEffectiveTimeOverlaps(std::vector<AutomationPoint> &points);
 
 template<typename ParameterT, typename AutomatableT>
 void applyAutomation(std::vector<AutomationPoint> points,
@@ -276,6 +277,7 @@ void applyAutomation(std::vector<AutomationPoint> points,
 
         // This assumes the points are ordered by time!
         std::sort(points.begin(), points.end(), pointsTimeSorter);
+        fixEffectiveTimeOverlaps(points);
         points = simplify(points);
 
         if(points.size() == 1) { // May have reduced to 1 during removal

--- a/reaper-adm-extension/src/reaper_adm/automationenvelope.cpp
+++ b/reaper-adm-extension/src/reaper_adm/automationenvelope.cpp
@@ -2,6 +2,14 @@
 #include <memory>
 #include "automationenvelope.h"
 
+namespace {
+std::chrono::nanoseconds nsMultiply(std::chrono::nanoseconds const &ns, double const multiplier) {
+    double asDouble = (double)ns.count() * multiplier;
+    long long asLongLong = asDouble + 0.5; // correct rounding
+    return std::chrono::nanoseconds(asLongLong);
+}
+}
+
 using namespace admplug;
 
 DefinedStartEnvelope::DefinedStartEnvelope(TrackEnvelope *trackEnvelope, ReaperAPI const& api) : trackEnvelope{trackEnvelope}, api{api}
@@ -11,8 +19,8 @@ DefinedStartEnvelope::DefinedStartEnvelope(TrackEnvelope *trackEnvelope, ReaperA
 
 void DefinedStartEnvelope::addPoint(AutomationPoint point)
 {
-    if(points.empty() && point.duration() > 0) {
-        points.emplace_back(point.time(), 0, point.value());
+    if(points.empty() && point.durationNs() > std::chrono::nanoseconds::zero()) {
+        points.emplace_back(point.timeNs(), std::chrono::nanoseconds::zero(), point.value());
     }
     points.push_back(point);
 }
@@ -29,7 +37,7 @@ void DefinedStartEnvelope::createPoints(double pointsOffset)
     bool sortPoints{false};
 
     for(auto& point : points) {
-        pointOnTimeline = point.time() + point.duration() + pointsOffset;
+        pointOnTimeline = point.effectiveTime() + pointsOffset;
         if (earliestPointOnTimeline < 0.0 || pointOnTimeline < earliestPointOnTimeline) {
             earliestPointOnTimeline = pointOnTimeline;
         }
@@ -76,54 +84,37 @@ void WrappingEnvelope::createPoints(double pointsOffset)
     automationEnvelope.createPoints(pointsOffset);
 }
 
-void WrappingEnvelope::addDiscontinuityPoints(AutomationPoint const& point) {
-    auto& points = automationEnvelope.getPoints();
+void WrappingEnvelope::addDiscontinuityPoints(AutomationPoint const& currentPoint) {
+    auto& previousPoint = automationEnvelope.getPoints().back();
+    auto distance = fabs(currentPoint.value() - previousPoint.value());
 
-    auto& previousPoint = points.back();
-    auto previousValue = previousPoint.value();
-    auto previousStartTime = previousPoint.time();
-    auto previousDuration = previousPoint.duration();
-    auto previousEffectiveTime = previousStartTime + previousDuration;
-
-    auto value = point.value();
-    auto startTime = point.time();
-    auto duration = point.duration();
-    auto effectiveTime = startTime + duration;
-    // Fix for floating-point precision errors in calculating effective time by adding start and duration.
-    if(startTime < previousEffectiveTime) {
-        startTime = previousEffectiveTime;
-        duration = effectiveTime - startTime;
-    }
-
-    auto distance = fabs(value - previousValue);
-
-    if(isTopToBottomWrap(value, previousValue)) {
-      double wrappedDistance = calcWrappedDistance(value, previousValue);
+    if(isTopToBottomWrap(currentPoint.value(), previousPoint.value())) {
+      double wrappedDistance = calcWrappedDistance(currentPoint.value(), previousPoint.value());
 
       if(wrappedDistance < distance) {
-        double wrapDurationProportion = (wrappedDistance == 0.0)? 0.0 : ((1.0 - previousValue) / wrappedDistance);
-        auto wrapDuration = wrapDurationProportion * duration;
-        auto wrapTime = startTime + wrapDuration;
-        if(previousEffectiveTime != startTime || previousValue != 1.0) {
-            automationEnvelope.addPoint(AutomationPoint{ startTime, wrapDuration, 1.0 });
+        double wrapDurationProportion = (wrappedDistance == 0.0)? 0.0 : ((1.0 - previousPoint.value()) / wrappedDistance);
+        std::chrono::nanoseconds wrapDuration{nsMultiply(currentPoint.durationNs(), wrapDurationProportion)};
+        std::chrono::nanoseconds wrapTime{ currentPoint.timeNs() + wrapDuration };
+        if(previousPoint.effectiveTimeNs() != currentPoint.timeNs() || previousPoint.value() != 1.0) {
+            automationEnvelope.addPoint(AutomationPoint{ currentPoint.timeNs(), wrapDuration, 1.0 });
         }
-        if(effectiveTime != wrapTime || value != 0.0) {
-            automationEnvelope.addPoint(AutomationPoint{ wrapTime, 0.0, 0.0 });
+        if(currentPoint.effectiveTimeNs() != wrapTime || currentPoint.value() != 0.0) {
+            automationEnvelope.addPoint(AutomationPoint{ wrapTime, std::chrono::nanoseconds::zero(), 0.0 });
         }
       }
     }
 
-    if(isBottomToTopWrap(value, previousValue)) {
-      auto wrappedDistance = calcWrappedDistance(previousValue, value);
+    if(isBottomToTopWrap(currentPoint.value(), previousPoint.value())) {
+      auto wrappedDistance = calcWrappedDistance(previousPoint.value(), currentPoint.value());
       if(wrappedDistance < distance) {
-        double wrapDurationProportion = (wrappedDistance == 0.0)? 0.0 : (previousValue / wrappedDistance);
-        auto wrapDuration = wrapDurationProportion * duration;
-        auto wrapTime = startTime + wrapDuration;
-        if(previousEffectiveTime != startTime || previousValue != 0.0) {
-            automationEnvelope.addPoint(AutomationPoint{ startTime, wrapDuration, 0.0 });
+        double wrapDurationProportion = (wrappedDistance == 0.0)? 0.0 : (previousPoint.value() / wrappedDistance);
+        std::chrono::nanoseconds wrapDuration{nsMultiply(currentPoint.durationNs(), wrapDurationProportion)};
+        std::chrono::nanoseconds wrapTime{ currentPoint.timeNs() + wrapDuration };
+        if(previousPoint.effectiveTimeNs() != currentPoint.timeNs() || previousPoint.value() != 0.0) {
+            automationEnvelope.addPoint(AutomationPoint{ currentPoint.timeNs(), wrapDuration, 0.0 });
         }
-        if(effectiveTime > wrapTime || value != 1.0) {
-            automationEnvelope.addPoint(AutomationPoint{ wrapTime, 0.0, 1.0 });
+        if(currentPoint.effectiveTimeNs() > wrapTime || currentPoint.value() != 1.0) {
+            automationEnvelope.addPoint(AutomationPoint{ wrapTime, std::chrono::nanoseconds::zero(), 1.0 });
         }
       }
     }

--- a/reaper-adm-extension/src/reaper_adm/automationenvelope.cpp
+++ b/reaper-adm-extension/src/reaper_adm/automationenvelope.cpp
@@ -77,17 +77,23 @@ void WrappingEnvelope::createPoints(double pointsOffset)
 }
 
 void WrappingEnvelope::addDiscontinuityPoints(AutomationPoint const& point) {
-  auto& points = automationEnvelope.getPoints();
-    auto value = point.value();
-    auto startTime = point.time();
-    auto duration = point.duration();
-    auto effectiveTime = startTime + duration;
+    auto& points = automationEnvelope.getPoints();
 
     auto& previousPoint = points.back();
     auto previousValue = previousPoint.value();
     auto previousStartTime = previousPoint.time();
     auto previousDuration = previousPoint.duration();
     auto previousEffectiveTime = previousStartTime + previousDuration;
+
+    auto value = point.value();
+    auto startTime = point.time();
+    auto duration = point.duration();
+    auto effectiveTime = startTime + duration;
+    // Fix for floating-point precision errors in calculating effective time by adding start and duration.
+    if(startTime < previousEffectiveTime) {
+        startTime = previousEffectiveTime;
+        duration = effectiveTime - startTime;
+    }
 
     auto distance = fabs(value - previousValue);
 
@@ -116,7 +122,7 @@ void WrappingEnvelope::addDiscontinuityPoints(AutomationPoint const& point) {
         if(previousEffectiveTime != startTime || previousValue != 0.0) {
             automationEnvelope.addPoint(AutomationPoint{ startTime, wrapDuration, 0.0 });
         }
-        if(effectiveTime != wrapTime || value != 1.0) {
+        if(effectiveTime > wrapTime || value != 1.0) {
             automationEnvelope.addPoint(AutomationPoint{ wrapTime, 0.0, 1.0 });
         }
       }

--- a/reaper-adm-extension/src/reaper_adm/automationpoint.cpp
+++ b/reaper-adm-extension/src/reaper_adm/automationpoint.cpp
@@ -9,23 +9,55 @@ AutomationPoint::AutomationPoint(double val) : AutomationPoint{ns::zero(), ns::z
 }
 
 AutomationPoint::AutomationPoint(std::chrono::nanoseconds timeNs, std::chrono::nanoseconds duration, double val) :
-    pointTime{timeNs.count() / 1000000000.0},
-    pointDuration{duration.count() / 1000000000.0},
-    pointValue{val} {
+    pointTime{timeNs},
+    pointDuration{duration},
+    pointValue{val}
+{
 }
 
-AutomationPoint::AutomationPoint(double timeSeconds, double duration, double val) : pointTime{timeSeconds}, pointDuration{duration}, pointValue{val}
+void AutomationPoint::setTimeNs(ns time)
 {
+    pointTime = time;
+}
+
+void AutomationPoint::setDurationNs(ns duration)
+{
+    pointDuration = duration;
+}
+
+void AutomationPoint::setDurationFromEffectiveTimeNs(ns effectiveTime)
+{
+    pointDuration = effectiveTime - pointTime;
 }
 
 double AutomationPoint::time() const
 {
-    return pointTime;
+    return pointTime.count() / 1000000000.0;
 }
 
 double AutomationPoint::duration() const
 {
+    return pointDuration.count() / 1000000000.0;
+}
+
+double AutomationPoint::effectiveTime() const
+{
+    return effectiveTimeNs().count()  / 1000000000.0;
+}
+
+ns AutomationPoint::timeNs() const
+{
+    return pointTime;
+}
+
+ns AutomationPoint::durationNs() const
+{
     return pointDuration;
+}
+
+ns AutomationPoint::effectiveTimeNs() const
+{
+    return pointTime + pointDuration;
 }
 
 double AutomationPoint::value() const

--- a/reaper-adm-extension/src/reaper_adm/automationpoint.h
+++ b/reaper-adm-extension/src/reaper_adm/automationpoint.h
@@ -9,13 +9,24 @@ class AutomationPoint
 public:
     explicit AutomationPoint(double val);
     AutomationPoint(std::chrono::nanoseconds timeNs, std::chrono::nanoseconds duration, double val);
-    AutomationPoint(double timeSeconds, double duration, double val);
+
+    void setTimeNs(std::chrono::nanoseconds time);
+    void setDurationNs(std::chrono::nanoseconds duration);
+    void setDurationFromEffectiveTimeNs(std::chrono::nanoseconds effectiveTime);
+
     double time() const;
     double duration() const;
+    double effectiveTime() const;
+
+    std::chrono::nanoseconds timeNs() const;
+    std::chrono::nanoseconds durationNs() const;
+    std::chrono::nanoseconds effectiveTimeNs() const;
+
     double value() const;
+
 private:
-    double pointTime;
-    double pointDuration;
+    std::chrono::nanoseconds pointTime;
+    std::chrono::nanoseconds pointDuration;
     double pointValue;
 };
 

--- a/reaper-adm-extension/src/reaper_adm/parameter.cpp
+++ b/reaper-adm-extension/src/reaper_adm/parameter.cpp
@@ -26,12 +26,12 @@ std::optional<double> admplug::getAdmParameterDefault(AdmParameter admParameter)
 
 AutomationPoint admplug::Parameter::forwardMap(AutomationPoint point) const
 {
-    return AutomationPoint(point.time(), point.duration(), forwardMap(point.value()));
+    return AutomationPoint(point.timeNs(), point.durationNs(), forwardMap(point.value()));
 }
 
 AutomationPoint admplug::Parameter::reverseMap(AutomationPoint point) const
 {
-    return AutomationPoint(point.time(), point.duration(), reverseMap(point.value()));
+    return AutomationPoint(point.timeNs(), point.durationNs(), reverseMap(point.value()));
 }
 
 std::unique_ptr<AutomationEnvelope> PluginParameter::getEnvelope(const Plugin &plugin) const

--- a/reaper-adm-extension/src/reaper_adm/parametervaluemapping.cpp
+++ b/reaper-adm-extension/src/reaper_adm/parametervaluemapping.cpp
@@ -12,12 +12,12 @@ AutomationPoint admplug::ParameterValueMapping::operator()(AutomationPoint point
 
 AutomationPoint admplug::ParameterValueMapping::forwardMap(AutomationPoint point) const
 {
-    return AutomationPoint(point.time(), point.duration(), forwardMap(point.value()));
+    return AutomationPoint(point.timeNs(), point.durationNs(), forwardMap(point.value()));
 }
 
 AutomationPoint admplug::ParameterValueMapping::reverseMap(AutomationPoint point) const
 {
-    return AutomationPoint(point.time(), point.duration(), reverseMap(point.value()));
+    return AutomationPoint(point.timeNs(), point.durationNs(), reverseMap(point.value()));
 }
 
 

--- a/reaper-adm-extension/test/reaper_adm/CMakeLists.txt
+++ b/reaper-adm-extension/test/reaper_adm/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(testreaper_adm
     $<TARGET_PROPERTY:Reaper_adm::reaper_adm,INCLUDE_DIRECTORIES>
 	${EPS_SHARED_DIR})
 
-set_property(TARGET testreaper_adm PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "../../../test/reaper_adm/")
+set_property(TARGET testreaper_adm PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "../../../../reaper-adm-extension/test/reaper_adm/")
 
 add_custom_command(TARGET testreaper_adm POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${REAPER_ADM_EXTENSION_SRC_DIR}/ADMPresets ${CMAKE_CURRENT_SOURCE_DIR}/data/UserPlugins/ADMPresets)
@@ -74,7 +74,7 @@ target_include_directories(testacceptreaper_adm
     $<TARGET_PROPERTY:Reaper_adm::reaper_adm,INCLUDE_DIRECTORIES>
 	${EPS_SHARED_DIR})
 
-set_property(TARGET testacceptreaper_adm PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "../../../test/reaper_adm/")
+set_property(TARGET testacceptreaper_adm PROPERTY VS_DEBUGGER_WORKING_DIRECTORY "../../../../reaper-adm-extension/test/reaper_adm/")
 
 add_test(
     NAME reaper_adm_acceptance_test


### PR DESCRIPTION
Because effective time is adding of 2 floats which can introduce precision error, it can be that the effective time of the previous block if AFTER the start time of the block you're processing. ~~This fix shifts start times according to the previous effective time to retain correct ordering. We're really only interested in effective time when placing points anyway - although those would be subject to precision error too!~~
~~This is the easiest fix. The best fix would be to use the adm::Time class throughout the entire code base, but that's huge work!~~
This fix uses chrono::nanoseconds in AutomationPoint class to avoid precision error when calculating effective time. Also includes a fixEffectiveTimeOverlaps function when processing the vector of AutomationPoints, which forces the effective time of a point to occur at or before the start time of the successive point (i.e, successive AudioBlockFormats rtime)