### PR TITLE
arm64 CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,17 @@ jobs:
         with:
           name: 'macOS_Latest_Clang_arm64'
           path: 'macOS_Latest_Clang_arm64'
+        
+      - name: 'un-tar x64'
+        run: tar -xf macOS_Latest_Clang_x64.tar && rm macOS_Latest_Clang_x64.tar
+        working-directory: macOS_Latest_Clang_x64
+        
+      - name: 'un-tar arm64'
+        run: tar -xf macOS_Latest_Clang_arm64.tar && rm macOS_Latest_Clang_arm64.tar
+        working-directory: macOS_Latest_Clang_arm64
+        
+      - name: 'dir listing'
+        run: ls -R
 
       - name: 'build ub'
         run: |
@@ -226,8 +237,14 @@ jobs:
             echo "Making UB Plugin from: $plugin"
             make_ub "$plugin"
           done
+          
+      - name: 'dir listing'
+        run: ls -R
+          
+      - name: 'tar ub'
+        run: tar -cvf macOS_Latest_Clang_universal.tar -C macOS_Latest_Clang_universal .
 
       - uses: actions/upload-artifact@v2
         with:
           name: 'macOS_Latest_Clang_universal'
-          path: 'macOS_Latest_Clang_universal'
+          path: 'macOS_Latest_Clang_universal.tar'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
             os: macos-latest
             package: true
             cmake_preset: "macos-arm64-packaging-release"
-            vcpkg_triplet: arm64-osx
+            vcpkg_triplet: arm64-osx-11_0
             test: false
     steps:
       - name: 'Checkout repo recursively.'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -159,7 +159,7 @@
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
-          "value": "arm64-osx"
+          "value": "arm64-osx-11_0"
         },
         "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg_triplets"
       }

--- a/vcpkg_triplets/arm64-osx-11_0.cmake
+++ b/vcpkg_triplets/arm64-osx-11_0.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+set(VCPKG_OSX_DEPLOYMENT_TARGET 11.0)
+set(VCPKG_C_FLAGS -mmacosx-version-min=11.0)
+set(VCPKG_CXX_FLAGS -mmacosx-version-min=11.0)


### PR DESCRIPTION
* Use arm64 triplet with minimum macos version 11.0
* Fix UB generation step (subtly broken since #136)

Previously the arm64 build used the default community triplet arm64-osx. At the time this was built the github action runners were on macos 11.0 which is also the specified minimum os version used when building. The action runners have since been updated causing the linker to emit warnings about a potential mismatch between the vckg build dependencies and the plugins/extension. This commit updates the build to use a modified version of the triplet which sets the minimum macos version when building the dependencies to 11.0 to match the main build.

The UB stage has been broken since artifact tar-ing was added to preserve
permissions on the project upgrade app, this fixes that by adding un-tar and
re-tar steps before and after lipo is used to combine the binaries. 