### PR TITLE
Update bundle identifiers

### DIFF
--- a/cmake_modules/juce_helpers.cmake
+++ b/cmake_modules/juce_helpers.cmake
@@ -21,7 +21,9 @@ function(add_juce_vst3_plugin PLUGIN_NAME)
     set(PLUGIN_OUTPUT_NAME "${PLUGIN_NAME}")
   endif()
 
-  set(PRODUCT_BUNDLE_IDENTIFIER "ear.${PLUGIN_NAME}")
+  string(REGEX REPLACE "[^0-9A-Za-z\\-\\.]" "-" PLUGIN_BUNDLE_ID ${PLUGIN_NAME})
+
+  set(PRODUCT_BUNDLE_IDENTIFIER "ch.ebu.ear.${PLUGIN_BUNDLE_ID}")
   set(_SUPPORT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${PLUGIN_NAME}_resources/)
   configure_file(${JUCE_SUPPORT_RESOURCES}/juce/AppConfig.h.in ${_SUPPORT_PATH}/AppConfig.h)
   configure_file(${JUCE_SUPPORT_RESOURCES}/juce/JuceHeader.h.in ${_SUPPORT_PATH}/JuceHeader.h)

--- a/shared/resources/osx/VST-Info.plist.in
+++ b/shared/resources/osx/VST-Info.plist.in
@@ -22,7 +22,7 @@
     <key>CFBundleVersion</key>
     <string>@PROJECT_VERSION@</string>
     <key>NSHumanReadableCopyright</key>
-    <string>Ear</string>
+    <string>(C) 2019-2022 BBC, (C) 2020-2021 EBU, (C) 2019-2021 IRT</string>
     <key>NSHighResolutionCapable</key>
     <true/>
   </dict>

--- a/tools/project_upgrade/CMakeLists.txt
+++ b/tools/project_upgrade/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(JUCE REQUIRED QUIET)
 set(MACOSX_BUNDLE_BUNDLE_NAME "EPS Project Upgrade Utility")
 set(MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}")
 set(MACOSX_BUNDLE_GUI_IDENTIFIER "ch.ebu.reaper_project_upgrade_gui")
+set(MACOSX_BUNDLE_COPYRIGHT "(C) 2019-2022 BBC, (C) 2020-2021 EBU, (C) 2019-2021 IRT")
 add_executable(project_upgrade_gui WIN32 MACOSX_BUNDLE)
 target_sources(project_upgrade_gui
         PRIVATE

--- a/tools/project_upgrade/CMakeLists.txt
+++ b/tools/project_upgrade/CMakeLists.txt
@@ -15,6 +15,10 @@ target_link_libraries(project_upgrade
         proj_upgrade)
 
 find_package(JUCE REQUIRED QUIET)
+
+set(MACOSX_BUNDLE_BUNDLE_NAME "EPS Project Upgrade Utility")
+set(MACOSX_BUNDLE_BUNDLE_VERSION "${PROJECT_VERSION}")
+set(MACOSX_BUNDLE_GUI_IDENTIFIER "ch.ebu.reaper_project_upgrade_gui")
 add_executable(project_upgrade_gui WIN32 MACOSX_BUNDLE)
 target_sources(project_upgrade_gui
         PRIVATE


### PR DESCRIPTION
Only allow valid characters in plugin bundle IDs as specified in
https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier

Give upgrade app a bundle ID so it can be notarized

Add NSHumanReadableCopyright key