### PR TITLE
Prevent debug assertion firing during programme removal

### DIFF
--- a/ear-production-suite-plugins/plugins/scene/src/scene_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_frontend_connector.cpp
@@ -568,6 +568,10 @@ void JuceSceneFrontendConnector::removeProgramme(int index) {
   std::lock_guard<std::mutex> programmeStoreLock(p_->getProgrammeStoreMutex());
   auto programme = p_->getProgrammeStore()->mutable_programme();
   programme->erase(programme->begin() + index);
+  auto selected_index = p_->getProgrammeStore()->selected_programme_index();
+  if(selected_index >= programme->size()) {
+    p_->getProgrammeStore()->set_selected_programme_index(std::max<int>(programme->size() - 1, 0));
+  }
   notifyProgrammeStoreChanged(p_->getProgrammeStoreCopy());
 }
 


### PR DESCRIPTION
When running a debug build, the assertion in [`SceneBackend::getSelectedProgramme` ](https://github.com/ebu/ear-production-suite/blob/fix_prog_remove_assertion/ear-production-suite-plugins/lib/src/scene_backend.cpp#L170-L180)
 would fail if there were 2 or more programmes and the right-most programme was removed. This happens after [`JuceSceneFrontendConnector::removeProgramme`](https://github.com/ebu/ear-production-suite/blob/9d61a7f28dafbb53ae2c768042feb502f3a7aef3/ear-production-suite-plugins/plugins/scene/src/scene_frontend_connector.cpp#L567-L576) is called.
The failure is becuase the programme is removed from the store, but the selected index is not updated and goes out of bounds.

I think the value of selected programme gets updated later (possibly via [`JuceFrontendConnector::tabSelected`](https://github.com/ebu/ear-production-suite/blob/9d61a7f28dafbb53ae2c768042feb502f3a7aef3/ear-production-suite-plugins/plugins/scene/src/scene_frontend_connector.cpp#L714-L716), which is why the current code 'works', but probably better to keep data in sync.

If we see another of these sync issues it might be worth wrapping the protobuf programme store in a class we can use to maintain invariants.

-- edit, actually this is really bad as I think we're accessing off the end of an array which is UB, even if it is currently working.
