### PR TITLE
Export speed-up and render dialog improvements

### DIFF
--- a/ear-production-suite-plugins/lib/include/binaural_monitoring_backend.hpp
+++ b/ear-production-suite-plugins/lib/include/binaural_monitoring_backend.hpp
@@ -96,6 +96,8 @@ class BinauralMonitoringBackend {
 
   std::shared_ptr<ear::plugin::ListenerOrientation> listenerOrientation;
 
+  bool isExporting() { return isExporting_; }
+
  private:
   void onSceneReceived(proto::SceneStore store);
   void onConnection(communication::ConnectionId connectionId,
@@ -133,6 +135,8 @@ class BinauralMonitoringBackend {
 
   std::mutex commonDefinitionHelperMutex_;
   AdmCommonDefinitionHelper commonDefinitionHelper{};
+
+  bool isExporting_{ false };
 };
 
 }  // namespace plugin

--- a/ear-production-suite-plugins/lib/include/monitoring_backend.hpp
+++ b/ear-production-suite-plugins/lib/include/monitoring_backend.hpp
@@ -32,6 +32,8 @@ class MonitoringBackend {
 
   GainHolder currentGains();
 
+  bool isExporting() { return isExporting_; }
+
  private:
   void onSceneReceived(proto::SceneStore store);
   void onConnection(communication::ConnectionId connectionId,
@@ -48,6 +50,7 @@ class MonitoringBackend {
   std::unique_ptr<communication::MonitoringMetadataReceiver> metadataReceiver_;
   communication::MonitoringControlConnection controlConnection_;
 
+  bool isExporting_{ false };
 };
 
 }  // namespace plugin

--- a/ear-production-suite-plugins/lib/include/scene_backend.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_backend.hpp
@@ -51,13 +51,13 @@ class SceneBackend {
   SceneBackend(SceneBackend &&) = delete;
   SceneBackend &operator=(SceneBackend &&) = delete;
   SceneBackend &operator=(const SceneBackend &) = delete;
-  void triggerMetadataSend();
+  void triggerMetadataSend(bool forExporting = false);
   void setup();
 
   std::pair<ItemStore, proto::ProgrammeStore> stores();
 
  private:
-  communication::MessageBuffer getMessage();
+  communication::MessageBuffer getMessage(bool forExporting = false);
   void onConnectionEvent(communication::SceneConnectionManager::Event,
                          communication::ConnectionId id);
   void initializeProgrammeStore();

--- a/ear-production-suite-plugins/lib/messages/scene_store.proto
+++ b/ear-production-suite-plugins/lib/messages/scene_store.proto
@@ -8,4 +8,5 @@ import "input_item_metadata.proto";
 message SceneStore {
   repeated MonitoringItemMetadata monitoring_items = 1;
   repeated InputItemMetadata all_available_items = 2;
+  optional bool is_exporting = 3 [default = false];
 }

--- a/ear-production-suite-plugins/lib/src/binaural_monitoring_backend.cpp
+++ b/ear-production-suite-plugins/lib/src/binaural_monitoring_backend.cpp
@@ -207,6 +207,8 @@ BinauralMonitoringBackend::getLatestObjectsTypeMetadata(ConnId id) {
 }
 
 void BinauralMonitoringBackend::onSceneReceived(proto::SceneStore store) {
+  isExporting_ = store.has_is_exporting() && store.is_exporting();
+
   size_t totalDsChannels = 0;
   size_t totalObjChannels = 0;
   size_t totalHoaChannels = 0;

--- a/ear-production-suite-plugins/lib/src/monitoring_backend.cpp
+++ b/ear-production-suite-plugins/lib/src/monitoring_backend.cpp
@@ -48,8 +48,10 @@ MonitoringBackend::~MonitoringBackend() {
 }
 
 void MonitoringBackend::onSceneReceived(proto::SceneStore store) {
+  isExporting_ = store.has_is_exporting() && store.is_exporting();
   updateActiveGains(std::move(store));
 }
+
 GainHolder MonitoringBackend::currentGains() {
   std::lock_guard<std::mutex> lock(gainsMutex_);
   return gains_;

--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
@@ -125,11 +125,15 @@ bool SceneAudioProcessor::isBusesLayoutSupported(
 
 void SceneAudioProcessor::processBlock(AudioBuffer<float>& buffer,
                                        MidiBuffer& midiMessages) {
-  backend_->triggerMetadataSend();
   doSampleRateChecks();
-  levelMeter_->process(buffer);
 
-  if (sendSamplesToExtension) {
+  if(!sendSamplesToExtension) {
+    backend_->triggerMetadataSend();
+    levelMeter_->process(buffer);
+
+  } else {
+    backend_->triggerMetadataSend(true);
+
     size_t sampleSize = sizeof(float);
     uint8_t numChannels = 64;
     size_t msg_size = buffer.getNumSamples() * numChannels * sampleSize;

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -238,7 +238,7 @@ BOOL CALLBACK RenderDialogControl::RenderDialogState::prepareRenderControl_pass2
             }
         }
 
-        if (getControlType(hwnd) == COMBOBOX) {
+        if (controlType == COMBOBOX) {
             // See if this is the 'Bounds' dropdown by setting it to the option we want - if successful, it was, and so disable it
             if (selectInComboBox(hwnd, REQUIRED_BOUNDS_COMBO_OPTION) != CB_ERR){
                 boundsControlHwnd = hwnd;

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -151,6 +151,17 @@ LRESULT RenderDialogControl::RenderDialogState::selectInComboBox(HWND hwnd, std:
 
 void RenderDialogControl::RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
 {
+    // Our dialog displayed - reset all vars (might not be the first time around)
+    boundsControlHwnd.reset();
+    sourceControlHwnd.reset();
+    presetsControlHwnd.reset();
+    sampleRateControlHwnd.reset();
+    channelsControlHwnd.reset();
+    sampleRateControlSetError = false;
+    channelsControlSetError = false;
+    sampleRateLastOption.clear();
+    channelsLastOption.clear();
+
     startedPrepareDialogControls = true; // Prevents paint message relauching this
     EnableWindow(GetDlgItem(hwndDlg, IDC_BUTTON_REFRESH), false);
     SetWindowText(GetDlgItem(hwndDlg, IDC_INFOPANE), LPCSTR("\r\nValidating Project Structure...\r\n\r\nPlease Wait..."));

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -49,7 +49,7 @@ private:
 
         enum ControlType{
             UNKNOWN,
-            TEXT, //Note: On OSX this can be editable text or a label. On windows, it is editable text.
+            TEXT, //Note: On OSX this can be editable text or a label. Mirrored this behaviour for Windows.
             BUTTON, //Note: On OSX this includes radios and checkboxes.
             COMBOBOX,
             EDITABLECOMBO
@@ -69,6 +69,7 @@ private:
         std::optional<HWND> presetsControlHwnd{};
         std::optional<HWND> sampleRateControlHwnd{};
         std::optional<HWND> channelsControlHwnd{};
+        std::optional<HWND> channelsLabelHwnd{};
         bool sampleRateControlSetError{false};
         bool channelsControlSetError{false};
 


### PR DESCRIPTION
Export was very slow with the binaural plugin. 

#83 has been open for a while which advised disabling monitoring plugins to squeeze more export performance and this is even more relevant now with the heavy load of the bin mon plugin. It also advised on ways to make the waveform display during rendering more relevant. This PR fixes both issues in a slightly different way:

## Monitoring bypass
- Scene knows when it is exporting due to connection to extension. It passes this state in monitoring metadata. 
  - It does not bother sending any more metadata until exporting is finished (no point - mon plugins don't need it)
- Monitoring backends (both LS and Bin) read and store this state.
- Monitoring AudioProcessors refer to that state to determine what to do during processBlocks:
  - If not exporting, method runs as normal
  - If exporting, input channels are simply summed and copied to all output channels. This is fast and bypasses BEAR/EAR signal processing, but still produces a relevant output (see below).

## Render dialog
- Stereo output waveform was confusing (why stereo, when this is ADM?). Force mono in render dialog so that we only see one waveform during rendering. 
  - The "Auto" text we used before was obviously invalid and this made REAPER default to Stereo. We set mono and hide the channels combobox and label (otherwise that's also confusing).
- With channels simply summed by mon plugins during export, the waveform shown in the render dialog is somewhat representative of content. 

### Other fixes:
- Correct resetting of state when "ADM BW64" option is selected in dialog, then unselected, then selected again.

Closes #83