### PR TITLE
Export Comms and Render Dialog fixes

### DIFF
--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
@@ -59,6 +59,9 @@ SceneAudioProcessor::SceneAudioProcessor()
 
 SceneAudioProcessor::~SceneAudioProcessor() {
   sendSamplesToExtension = false;
+  backend_.reset();
+  commandSocket->close();
+  delete commandSocket;
   samplesSocket->close();
   delete samplesSocket;
 }

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
@@ -2,14 +2,13 @@
 #include "PluginProcessor.h"
 #include <fstream>
 
-AdmStemPluginAudioProcessor::AdmStemPluginAudioProcessor() :
+AdmStemPluginAudioProcessor::AdmStemPluginAudioProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations
-     AudioProcessor (BusesProperties()
+  : AudioProcessor (BusesProperties()
          .withInput("Input", AudioChannelSet::discreteChannels(64), true)
          .withOutput("Output", AudioChannelSet::discreteChannels(64), true)
-     ),
+     )
 #endif
-    nngSelfRegister{ std::make_shared<NngSelfRegister>() } // Having a handle to this means we don't teardown the NNG globals prematurely.
 {
     CRT_SET
     sendSamples = false;

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.h
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.h
@@ -85,8 +85,6 @@ public:
 private:
     AdmStemPluginAudioProcessorEditor* editor();
 
-    std::shared_ptr<NngSelfRegister> nngSelfRegister;
-
     int calcNumChannels();
     void updateNumChnsParam(bool force = false);
     void updateAdmParameters(bool force = false);

--- a/reaper-adm-extension/src/reaper_adm/exportaction.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction.cpp
@@ -1,6 +1,6 @@
 #include "exportaction.h"
 
-ExportManager::ExportManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst, reaper_plugin_info_t *rec) : api{ api }
+ExportManager::ExportManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst, reaper_plugin_info_t *rec) : api{ api }, rec{ rec }
 {
     if(!(this->api)) {
         throw std::logic_error("api is null, make sure when getManager() is first called, a valid API pointer is provided.");
@@ -24,7 +24,10 @@ ExportManager::ExportManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINST
 }
 
 ExportManager::~ExportManager() {
-    nngHandle.reset(); // This handle will be lost anyway, but just to be explicit...
+    if (rec && rec->Register("-pcmsink", &admSinkReg)) {
+        printf("DeRegistered Sink!\n");
+    }
+    nngHandle.reset(); // This handle will be lost anyway, but just to be explicit... (calls nng_fini to tidy up globals and false mem leak messages)
 }
 
 ExportManager &ExportManager::getManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst, reaper_plugin_info_t *rec)

--- a/reaper-adm-extension/src/reaper_adm/exportaction.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction.cpp
@@ -13,7 +13,6 @@ ExportManager::ExportManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINST
     }
 
     dialogControl = std::make_unique<RenderDialogControl>(api, inst);
-    nngHandle = std::make_shared<NngSelfRegister>(); // Prevents the library closing down prematurely
 
     admSinkReg = pcmsink_register_t {
             ExportInfo.GetFmt,

--- a/reaper-adm-extension/src/reaper_adm/exportaction.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction.cpp
@@ -19,15 +19,12 @@ ExportManager::ExportManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINST
     if (rec->Register("pcmsink", &admSinkReg)) {
         printf("Registered normal Sink!\n");
     }
-
-    nngHandle = std::make_unique<NngSelfRegister>();
 }
 
 ExportManager::~ExportManager() {
     if (rec && rec->Register("-pcmsink", &admSinkReg)) {
         printf("DeRegistered Sink!\n");
     }
-    nngHandle.reset(); // This handle will be lost anyway, but just to be explicit... (calls nng_fini to tidy up globals and false mem leak messages)
 }
 
 ExportManager &ExportManager::getManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst, reaper_plugin_info_t *rec)

--- a/reaper-adm-extension/src/reaper_adm/exportaction.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction.h
@@ -15,7 +15,6 @@ namespace admplug {
         ~ExportManager();
         static ExportManager& getManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst, reaper_plugin_info_t *rec);
         static ExportManager& getManager();
-        static void closeManager();
 
         static struct ExportInfoStruct {
             static const unsigned int SINK_FOURCC{ REAPER_FOURCC('a', 'd', 'm', ' ') };
@@ -38,8 +37,6 @@ namespace admplug {
         } ExportInfo;
 
     private:
-        static ExportManager* exportMan;
-
         static const char* GetExtensionIfMatch(const void *cfg, int cfg_l)
         {
             return ExportInfo.cfgMatch(cfg, cfg_l)? ExportInfo.GetExtension() : NULL;
@@ -58,14 +55,13 @@ namespace admplug {
 
         static HWND ShowConfigIfMatch(const void *cfg, int cfg_l, HWND parent)
         {
-            return ExportInfo.cfgMatch(cfg, cfg_l)? RenderDialogControl::getInstance()->ShowConfig(cfg, cfg_l,parent) : 0;
+            return ExportInfo.cfgMatch(cfg, cfg_l)? RenderDialogControl::getInstance().ShowConfig(cfg, cfg_l,parent) : 0;
         }
 
         ExportManager(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst, reaper_plugin_info_t *rec);
 
         std::shared_ptr<ReaperAPI> api;
         pcmsink_register_t admSinkReg;
-        std::unique_ptr<RenderDialogControl> dialogControl;
         std::shared_ptr<NngSelfRegister> nngHandle;
     };
 };

--- a/reaper-adm-extension/src/reaper_adm/exportaction.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction.h
@@ -62,6 +62,7 @@ namespace admplug {
 
         std::shared_ptr<ReaperAPI> api;
         pcmsink_register_t admSinkReg;
-        std::shared_ptr<NngSelfRegister> nngHandle;
+        reaper_plugin_info_t *rec;
+        std::shared_ptr<NngSelfRegister> nngHandle; // Used to call nng_fini on ext close
     };
 };

--- a/reaper-adm-extension/src/reaper_adm/exportaction.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction.h
@@ -63,6 +63,5 @@ namespace admplug {
         std::shared_ptr<ReaperAPI> api;
         pcmsink_register_t admSinkReg;
         reaper_plugin_info_t *rec;
-        std::shared_ptr<NngSelfRegister> nngHandle; // Used to call nng_fini on ext close
     };
 };

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -11,6 +11,7 @@
 #define EXPECTED_FIRST_SAMPLE_RATE_COMBO_OPTION "8000"
 #define EXPECTED_FIRST_CHANNEL_COUNT_COMBO_OPTION "Mono"
 #define EXPECTED_PRESETS_BUTTON_TEXT "Presets"
+#define EXPECTED_NORMALIZE_BUTTON_TEXT "Normalize/Limit..."
 #define REQUIRED_SOURCE_COMBO_OPTION "Master mix"
 #define REQUIRED_BOUNDS_COMBO_OPTION "Entire project"
 #define EXPECTED_CHANNEL_COUNT_LABEL_TEXT "Channels:"
@@ -156,6 +157,7 @@ void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
     boundsControlHwnd.reset();
     sourceControlHwnd.reset();
     presetsControlHwnd.reset();
+    normalizeControlHwnd.reset();
     sampleRateControlHwnd.reset();
     channelsControlHwnd.reset();
     channelsLabelHwnd.reset();
@@ -206,6 +208,11 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lP
             if (winStr == EXPECTED_PRESETS_BUTTON_TEXT){
                 // This is the presets button which could be used to override our forced settings - disable it
                 presetsControlHwnd = hwnd;
+                EnableWindow(hwnd, false);
+            }
+            if (winStr == EXPECTED_NORMALIZE_BUTTON_TEXT){
+                // This is the normalization config which will not work for this as we don't use the sink feed anyway - disable it
+                normalizeControlHwnd = hwnd;
                 EnableWindow(hwnd, false);
             }
         }
@@ -382,6 +389,7 @@ WDL_DLGRET RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wPa
         }
 
         auto infoPaneText = getAdmExportVstsInfoString();
+        // Note that some controls are not checked as they are not present in all versions of REAPER anyway, so it's OK for them to be missing
         bool allControlsSuccessful = boundsControlHwnd.has_value() &&
             sourceControlHwnd.has_value() &&
             presetsControlHwnd.has_value() &&
@@ -435,6 +443,7 @@ WDL_DLGRET RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wPa
         // Reenable the controls we disabled.
         if(boundsControlHwnd) EnableWindow(*boundsControlHwnd, true);
         if(presetsControlHwnd) EnableWindow(*presetsControlHwnd, true);
+        if(normalizeControlHwnd) EnableWindow(*normalizeControlHwnd, true);
         if(sourceControlHwnd) EnableWindow(*sourceControlHwnd, true);
 
         // NOTE: Sample Rate and Channels controls are;

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -13,6 +13,8 @@
 #define EXPECTED_PRESETS_BUTTON_TEXT "Presets"
 #define EXPECTED_NORMALIZE_BUTTON_TEXT "Normalize/Limit..."
 #define EXPECTED_SECOND_PASS_CHECKBOX_TEXT "2nd pass render"
+#define EXPECTED_MONO2MONO_CHECKBOX_TEXT "Tracks with only mono media to mono files"
+#define EXPECTED_MULTI2MULTI_CHECKBOX_TEXT "Multichannel tracks to multichannel files"
 #define REQUIRED_SOURCE_COMBO_OPTION "Master mix"
 #define REQUIRED_BOUNDS_COMBO_OPTION "Entire project"
 #define EXPECTED_CHANNEL_COUNT_LABEL_TEXT "Channels:"
@@ -170,6 +172,8 @@ void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
     presetsControlHwnd.reset();
     normalizeControlHwnd.reset();
     secondPassControlHwnd.reset();
+    monoToMonoControlHwnd.reset();
+    multiToMultiControlHwnd.reset();
     sampleRateControlHwnd.reset();
     channelsControlHwnd.reset();
     channelsLabelHwnd.reset();
@@ -232,6 +236,18 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lP
                 // Could probably be recified, but disable as quick fix for now
                 secondPassControlHwnd = hwnd;
                 secondPassLastState = getCheckboxState(hwnd);
+                setCheckboxState(hwnd, false);
+                EnableWindow(hwnd, false);
+            }
+            if (winStr == EXPECTED_MONO2MONO_CHECKBOX_TEXT){
+                monoToMonoControlHwnd = hwnd;
+                monoToMonoLastState = getCheckboxState(hwnd);
+                setCheckboxState(hwnd, false);
+                EnableWindow(hwnd, false);
+            }
+            if (winStr == EXPECTED_MULTI2MULTI_CHECKBOX_TEXT){
+                multiToMultiControlHwnd = hwnd;
+                multiToMultiLastState = getCheckboxState(hwnd);
                 setCheckboxState(hwnd, false);
                 EnableWindow(hwnd, false);
             }
@@ -469,6 +485,14 @@ WDL_DLGRET RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wPa
         if(secondPassControlHwnd) {
             EnableWindow(*secondPassControlHwnd, true);
             setCheckboxState(*secondPassControlHwnd, secondPassLastState);
+        }
+        if(monoToMonoControlHwnd) {
+            EnableWindow(*monoToMonoControlHwnd, true);
+            setCheckboxState(*monoToMonoControlHwnd, monoToMonoLastState);
+        }
+        if(multiToMultiControlHwnd) {
+            EnableWindow(*multiToMultiControlHwnd, true);
+            setCheckboxState(*multiToMultiControlHwnd, multiToMultiLastState);
         }
 
         // NOTE: Sample Rate and Channels controls are;

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -23,13 +23,13 @@ int MakeWParam(int loWord, int hiWord)
     return (loWord & 0xFFFF) + ((hiWord & 0xFFFF) << 16);
 }
 
-RenderDialogControl::RenderDialogState::RenderDialogState(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst) : reaperApi{ api }, reaperInst{ *inst } {
+RenderDialogState::RenderDialogState(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst) : reaperApi{ api }, reaperInst{ *inst } {
 }
 
-RenderDialogControl::RenderDialogState::~RenderDialogState() {
+RenderDialogState::~RenderDialogState() {
 }
 
-RenderDialogControl::RenderDialogState::ControlType RenderDialogControl::RenderDialogState::getControlType(HWND hwnd){
+RenderDialogState::ControlType RenderDialogState::getControlType(HWND hwnd){
 
     if (!hwnd || !IsWindow(hwnd)) return UNKNOWN;
 
@@ -71,7 +71,7 @@ RenderDialogControl::RenderDialogState::ControlType RenderDialogControl::RenderD
     return UNKNOWN;
 }
 
-HWND RenderDialogControl::RenderDialogState::getComboBoxEdit(HWND hwnd){
+HWND RenderDialogState::getComboBoxEdit(HWND hwnd){
     auto controlType = getControlType(hwnd);
     if(controlType == COMBOBOX) return hwnd;
     if(controlType != EDITABLECOMBO) return HWND();
@@ -89,7 +89,7 @@ HWND RenderDialogControl::RenderDialogState::getComboBoxEdit(HWND hwnd){
     return HWND();
 }
 
-std::string RenderDialogControl::RenderDialogState::getComboBoxItemText(HWND hwnd, int itemIndex)
+std::string RenderDialogState::getComboBoxItemText(HWND hwnd, int itemIndex)
 {
     auto controlType = getControlType(hwnd);
     if(controlType != COMBOBOX && controlType != EDITABLECOMBO) return std::string();
@@ -102,14 +102,14 @@ std::string RenderDialogControl::RenderDialogState::getComboBoxItemText(HWND hwn
     return std::string(itmtxt);
 }
 
-std::string RenderDialogControl::RenderDialogState::getWindowText(HWND hwnd)
+std::string RenderDialogState::getWindowText(HWND hwnd)
 {
     char wintxt[100];
     GetWindowText(hwnd, wintxt, 100);
     return std::string(wintxt);
 }
 
-HWND RenderDialogControl::RenderDialogState::ShowConfig(const void *cfg, int cfg_l, HWND parent)
+HWND RenderDialogState::ShowConfig(const void *cfg, int cfg_l, HWND parent)
 {
         const void *x[2] = { cfg,(void *)&cfg_l };
         return CreateDialogParam(reaperInst, MAKEINTRESOURCE(IDD_EXPORT), parent,
@@ -117,7 +117,7 @@ HWND RenderDialogControl::RenderDialogState::ShowConfig(const void *cfg, int cfg
             (LPARAM)x);
 }
 
-LRESULT RenderDialogControl::RenderDialogState::selectInComboBox(HWND hwnd, std::string text) {
+LRESULT RenderDialogState::selectInComboBox(HWND hwnd, std::string text) {
 #ifdef WIN32
     auto lparam = text.c_str();
     // Find item
@@ -149,7 +149,7 @@ LRESULT RenderDialogControl::RenderDialogState::selectInComboBox(HWND hwnd, std:
 #endif
 }
 
-void RenderDialogControl::RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
+void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
 {
     // Our dialog displayed - reset all vars (might not be the first time around)
     boundsControlHwnd.reset();
@@ -172,7 +172,7 @@ void RenderDialogControl::RenderDialogState::startPreparingRenderControls(HWND h
              (TIMERPROC)NULL);    // no timer callback (use window message)
 }
 
-BOOL CALLBACK RenderDialogControl::RenderDialogState::prepareRenderControl_pass1(HWND hwnd, LPARAM lParam) { // Caps BOOL is actually int for EnumChildWindows compatibility
+BOOL CALLBACK RenderDialogState::prepareRenderControl_pass1(HWND hwnd, LPARAM lParam) { // Caps BOOL is actually int for EnumChildWindows compatibility
                                                                 // Prepare Render Dialog Control for ADM export.
                                                                 // This will involve fixing some values and disabling those controls
 
@@ -191,7 +191,7 @@ BOOL CALLBACK RenderDialogControl::RenderDialogState::prepareRenderControl_pass1
     return true; // MUST return true to continue iterating through controls
 }
 
-BOOL CALLBACK RenderDialogControl::RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lParam) { // Caps BOOL is actually int for EnumChildWindows compatibility
+BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lParam) { // Caps BOOL is actually int for EnumChildWindows compatibility
                                                                                                              // Prepare Render Dialog Control for ADM export.
                                                                                                              // This will involve fixing some values and disabling those controls
 
@@ -260,7 +260,7 @@ BOOL CALLBACK RenderDialogControl::RenderDialogState::prepareRenderControl_pass2
     return true; // MUST return true to continue iterating through controls
 }
 
-std::string RenderDialogControl::RenderDialogState::getAdmExportVstsInfoString() {
+std::string RenderDialogState::getAdmExportVstsInfoString() {
     std::string itemStarter{ "\r\n - " };
     std::string op;
 
@@ -307,7 +307,7 @@ std::string RenderDialogControl::RenderDialogState::getAdmExportVstsInfoString()
     return op;
 }
 
-WDL_DLGRET RenderDialogControl::RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+WDL_DLGRET RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {
@@ -459,4 +459,15 @@ WDL_DLGRET RenderDialogControl::RenderDialogState::wavecfgDlgProc(HWND hwndDlg, 
 
     }
     return 0;
+}
+
+RenderDialogControl & RenderDialogControl::getInstance(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE * inst)
+{
+    static RenderDialogControl singleton {api, inst};
+    return singleton;
+}
+
+RenderDialogControl & RenderDialogControl::getInstance()
+{
+    return getInstance(nullptr, nullptr);
 }

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -15,6 +15,7 @@
 #define REQUIRED_BOUNDS_COMBO_OPTION "Entire project"
 #define EXPECTED_CHANNEL_COUNT_LABEL_TEXT "Channels:"
 #define REQUIRED_CHANNEL_COUNT_COMBO_OPTION "Mono"
+#define EXPECTED_FIRST_RESAMPLE_MODE_COMBO_OPTION "Point Sampling (lowest quality, retro)"
 
 #define TIMER_ID 1
 
@@ -158,6 +159,7 @@ void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
     sampleRateControlHwnd.reset();
     channelsControlHwnd.reset();
     channelsLabelHwnd.reset();
+    resampleModeControlHwnd.reset();
     sampleRateControlSetError = false;
     channelsControlSetError = false;
     sampleRateLastOption.clear();
@@ -244,6 +246,13 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lP
                 channelsControlSetError |= (selectInComboBox(hwnd, REQUIRED_CHANNEL_COUNT_COMBO_OPTION) == CB_ERR);
                 UpdateWindow(editControl);
                 ShowWindow(hwnd, SW_HIDE);
+            }
+            // See if this is the resample mode dropdown by seeing if the first item is EXPECTED_FIRST_RESAMPLE_MODE_COMBO_OPTION
+            if(itemText == EXPECTED_FIRST_RESAMPLE_MODE_COMBO_OPTION) {
+                resampleModeControlHwnd = hwnd;
+                auto editControl = getComboBoxEdit(hwnd);
+                EnableWindow(editControl, false);
+                UpdateWindow(editControl);
             }
         }
 
@@ -452,6 +461,11 @@ WDL_DLGRET RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wPa
         }
         if(channelsLabelHwnd) {
             ShowWindow(*channelsLabelHwnd, SW_SHOW);
+        }
+        if(resampleModeControlHwnd) {
+            auto editControl = getComboBoxEdit(*resampleModeControlHwnd);
+            EnableWindow(editControl, true);
+            UpdateWindow(editControl);
         }
 
         return 0;

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -52,12 +52,16 @@ private:
     std::optional<HWND> secondPassControlHwnd{};
     std::optional<HWND> normalizeControlHwnd{};
     std::optional<HWND> resampleModeControlHwnd{};
+    std::optional<HWND> monoToMonoControlHwnd{};
+    std::optional<HWND> multiToMultiControlHwnd{};
     bool sampleRateControlSetError{false};
     bool channelsControlSetError{false};
 
     std::string sampleRateLastOption{};
     std::string channelsLastOption{};
     bool secondPassLastState{ false };
+    bool monoToMonoLastState{ false };
+    bool multiToMultiLastState{ false };
 
     std::shared_ptr<AdmExportHandler> admExportHandler;
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -37,6 +37,8 @@ private:
     std::string getComboBoxItemText(HWND hwnd, int idx = 0);
     std::string getWindowText(HWND hwnd);
     LRESULT selectInComboBox(HWND hwnd, std::string text);
+    bool getCheckboxState(HWND hwnd);
+    void setCheckboxState(HWND hwnd, bool state);
 
     std::shared_ptr<ReaperAPI> reaperApi;
     REAPER_PLUGIN_HINSTANCE reaperInst;
@@ -47,6 +49,7 @@ private:
     std::optional<HWND> sampleRateControlHwnd{};
     std::optional<HWND> channelsControlHwnd{};
     std::optional<HWND> channelsLabelHwnd{};
+    std::optional<HWND> secondPassControlHwnd{};
     std::optional<HWND> normalizeControlHwnd{};
     std::optional<HWND> resampleModeControlHwnd{};
     bool sampleRateControlSetError{false};
@@ -54,6 +57,7 @@ private:
 
     std::string sampleRateLastOption{};
     std::string channelsLastOption{};
+    bool secondPassLastState{ false };
 
     std::shared_ptr<AdmExportHandler> admExportHandler;
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -47,6 +47,7 @@ private:
     std::optional<HWND> sampleRateControlHwnd{};
     std::optional<HWND> channelsControlHwnd{};
     std::optional<HWND> channelsLabelHwnd{};
+    std::optional<HWND> normalizeControlHwnd{};
     std::optional<HWND> resampleModeControlHwnd{};
     bool sampleRateControlSetError{false};
     bool channelsControlSetError{false};

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -27,7 +27,7 @@ private:
     enum ControlType{
         UNKNOWN,
         TEXT, //Note: On OSX this can be editable text or a label. Mirrored this behaviour for Windows.
-        BUTTON, //Note: On OSX this includes radios and checkboxes.
+        BUTTON, //Note: This includes radios and checkboxes.
         COMBOBOX,
         EDITABLECOMBO
     };

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -47,6 +47,7 @@ private:
     std::optional<HWND> sampleRateControlHwnd{};
     std::optional<HWND> channelsControlHwnd{};
     std::optional<HWND> channelsLabelHwnd{};
+    std::optional<HWND> resampleModeControlHwnd{};
     bool sampleRateControlSetError{false};
     bool channelsControlSetError{false};
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -12,96 +12,83 @@
 
 using namespace admplug;
 
+class RenderDialogControl;
+
+class RenderDialogState {
+public:
+    RenderDialogState(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst);
+    ~RenderDialogState();
+
+    HWND ShowConfig(const void *cfg, int cfg_l, HWND parent);
+
+private:
+    friend class RenderDialogControl;
+
+    enum ControlType{
+        UNKNOWN,
+        TEXT, //Note: On OSX this can be editable text or a label. Mirrored this behaviour for Windows.
+        BUTTON, //Note: On OSX this includes radios and checkboxes.
+        COMBOBOX,
+        EDITABLECOMBO
+    };
+
+    ControlType getControlType(HWND hwnd);
+    HWND getComboBoxEdit(HWND hwnd);
+    std::string getComboBoxItemText(HWND hwnd, int idx = 0);
+    std::string getWindowText(HWND hwnd);
+    LRESULT selectInComboBox(HWND hwnd, std::string text);
+
+    std::shared_ptr<ReaperAPI> reaperApi;
+    REAPER_PLUGIN_HINSTANCE reaperInst;
+
+    std::optional<HWND> boundsControlHwnd{};
+    std::optional<HWND> sourceControlHwnd{};
+    std::optional<HWND> presetsControlHwnd{};
+    std::optional<HWND> sampleRateControlHwnd{};
+    std::optional<HWND> channelsControlHwnd{};
+    std::optional<HWND> channelsLabelHwnd{};
+    bool sampleRateControlSetError{false};
+    bool channelsControlSetError{false};
+
+    std::string sampleRateLastOption{};
+    std::string channelsLastOption{};
+
+    std::shared_ptr<AdmExportHandler> admExportHandler;
+
+    void startPreparingRenderControls(HWND hwndDlg);
+    BOOL CALLBACK prepareRenderControl_pass1(HWND hwnd, LPARAM lParam);
+    BOOL CALLBACK prepareRenderControl_pass2(HWND hwnd, LPARAM lParam);
+    std::string getAdmExportVstsInfoString();
+    WDL_DLGRET wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+    bool startedPrepareDialogControls{ false };
+};
+
 class RenderDialogControl {
 public:
-    RenderDialogControl(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst) : stateSingleton{getInstance(api, inst)} {}
-    ~RenderDialogControl() {}
+    static RenderDialogControl& getInstance(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst);
+    static RenderDialogControl& getInstance();
 
     // Static callback methods which forward to the RenderDialogState instance (singleton)
     // Means we don't need to worry about binding methods.
 
     static WDL_DLGRET wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {
-        return RenderDialogControl::getInstance()->wavecfgDlgProc(hwndDlg, uMsg, wParam, lParam);
+        return getInstance().state.wavecfgDlgProc(hwndDlg, uMsg, wParam, lParam);
     }
 
     static HWND ShowConfig(const void *cfg, int cfg_l, HWND parent) {
-        return RenderDialogControl::getInstance()->ShowConfig(cfg, cfg_l,parent);
+        return getInstance().state.ShowConfig(cfg, cfg_l,parent);
     }
 
     static BOOL CALLBACK callback_PrepareRenderControl_pass1(HWND hwnd, LPARAM lParam) {
-        return RenderDialogControl::getInstance()->prepareRenderControl_pass1(hwnd, lParam);
+        return getInstance().state.prepareRenderControl_pass1(hwnd, lParam);
     }
 
     static BOOL CALLBACK callback_PrepareRenderControl_pass2(HWND hwnd, LPARAM lParam) {
-        return RenderDialogControl::getInstance()->prepareRenderControl_pass2(hwnd, lParam);
+        return getInstance().state.prepareRenderControl_pass2(hwnd, lParam);
     }
 
 private:
-    class RenderDialogState {
-    public:
-        RenderDialogState(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst);
-        ~RenderDialogState();
-
-        HWND ShowConfig(const void *cfg, int cfg_l, HWND parent);
-
-    private:
-        friend class RenderDialogControl;
-
-        enum ControlType{
-            UNKNOWN,
-            TEXT, //Note: On OSX this can be editable text or a label. Mirrored this behaviour for Windows.
-            BUTTON, //Note: On OSX this includes radios and checkboxes.
-            COMBOBOX,
-            EDITABLECOMBO
-        };
-
-        ControlType getControlType(HWND hwnd);
-        HWND getComboBoxEdit(HWND hwnd);
-        std::string getComboBoxItemText(HWND hwnd, int idx = 0);
-        std::string getWindowText(HWND hwnd);
-        LRESULT selectInComboBox(HWND hwnd, std::string text);
-
-        std::shared_ptr<ReaperAPI> reaperApi;
-        REAPER_PLUGIN_HINSTANCE reaperInst;
-
-        std::optional<HWND> boundsControlHwnd{};
-        std::optional<HWND> sourceControlHwnd{};
-        std::optional<HWND> presetsControlHwnd{};
-        std::optional<HWND> sampleRateControlHwnd{};
-        std::optional<HWND> channelsControlHwnd{};
-        std::optional<HWND> channelsLabelHwnd{};
-        bool sampleRateControlSetError{false};
-        bool channelsControlSetError{false};
-
-        std::string sampleRateLastOption{};
-        std::string channelsLastOption{};
-
-        std::shared_ptr<AdmExportHandler> admExportHandler;
-
-        void startPreparingRenderControls(HWND hwndDlg);
-        BOOL CALLBACK prepareRenderControl_pass1(HWND hwnd, LPARAM lParam);
-        BOOL CALLBACK prepareRenderControl_pass2(HWND hwnd, LPARAM lParam);
-        std::string getAdmExportVstsInfoString();
-        WDL_DLGRET wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-
-        bool startedPrepareDialogControls{ false };
-    };
-
-    std::shared_ptr<RenderDialogState> stateSingleton;
-    inline static std::weak_ptr<RenderDialogState> stateSingletonStatic;
-
-public:
-    static std::shared_ptr<RenderDialogState> getInstance(std::shared_ptr<ReaperAPI> api = nullptr, REAPER_PLUGIN_HINSTANCE *inst  = nullptr) {
-        if(std::shared_ptr<RenderDialogState> singleton = stateSingletonStatic.lock()) {
-            return singleton;
-        } else {
-            if (api == nullptr || inst == nullptr) {
-                throw std::logic_error("Expected api and inst handles passed to getInstance on first instance!");
-            }
-            singleton = std::make_shared<RenderDialogState>(api, inst);
-            stateSingletonStatic = singleton;
-            return singleton;
-        }
-    }
-
+    RenderDialogControl(std::shared_ptr<ReaperAPI> api, REAPER_PLUGIN_HINSTANCE *inst) : state{api, inst} {}
+    RenderDialogState state;
 };

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -52,6 +52,7 @@ struct CrtBreakAllocSetter {
 
 CrtBreakAllocSetter g_crtBreakAllocSetter;
 */
+
 namespace {
 #ifdef WIN32
 const std::map<const std::string, const int> defaultMenuPositions = {

--- a/reaper-adm-extension/src/reaper_adm/reaperhost.cpp
+++ b/reaper-adm-extension/src/reaper_adm/reaperhost.cpp
@@ -34,7 +34,6 @@ admplug::ReaperHost::ReaperHost(REAPER_PLUGIN_HINSTANCE plug_hinstance, reaper_p
 
         // Extension Closing Down!!!
 
-        prepareToClose();
     }
 }
 
@@ -42,12 +41,6 @@ admplug::ReaperHost::~ReaperHost() {
     // Use with caution! This destructor will run every time the REAPER_PLUGIN_ENTRYPOINT runs!
     // i.e, it will construct and destruct on start up of the extension,
     //      AND construct and destruct on shutdown of the extension!
-}
-
-void admplug::ReaperHost::prepareToClose()
-{
-    ExportManager::closeManager();
-    // If any other managers need to tidy up before closing, put their clean-up methods here
 }
 
 HWND admplug::ReaperHost::parentWindow()

--- a/reaper-adm-extension/src/reaper_adm/reaperhost.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperhost.h
@@ -29,7 +29,6 @@ class ReaperHost {
 public:
     ReaperHost(REAPER_PLUGIN_HINSTANCE plug_hinstance, reaper_plugin_info_t* plug_info, bool testAPI = true);
     ~ReaperHost();
-    void prepareToClose();
 
     HWND parentWindow();
     std::shared_ptr<ReaperAPI> api();

--- a/shared/helper/nng_wrappers.h
+++ b/shared/helper/nng_wrappers.h
@@ -197,7 +197,7 @@ private:
 
 class SocketBase {
 public:
-    SocketBase() : nngSelfRegister{std::make_shared<NngSelfRegister>()} {}
+    SocketBase() {}
     ~SocketBase() {}
 
     int getPort() {
@@ -251,7 +251,6 @@ protected:
     }
 
 private:
-    std::shared_ptr<NngSelfRegister> nngSelfRegister;
     int port{0};
     bool socketOpen{false};
 };


### PR DESCRIPTION
This PR combines the comms-fixes and render-dialog-fixes branches (latter is based off the former)

## Export Comms Fixes

**Problem**: Hang on OSX when trying to render after instantiating either an ADM Export Source or EAR Scene plugin after another EAR Scene.
**Issue**: It seems that an `nng_listen` on POSIX systems for a REQ-REP connection will return an `NNG_EADDRINUSE` if the address is being used (as expected) but in the process it disrupts the connection already on there. No messages are delivered on that connection anymore and they don't even time out - just hang.
**Fix**: For posix since it's all based around the filesystem, we can just do a `stat` to see if the address is in use without disturbing it.

**Sub-problem**: "Command" addresses are not being reused once released. 
**Issue**: Sockets not destroyed
**Fix**: Destroy socket in Processor destructor

**Sub-problem**: Reused "Command" addresses are not working after deleting and re-adding a Scene plugin
**Issue**: There is a `NngSelfRegister` mechanism which attempts to keep track of everything using NNG and calls `nng_fini` to clear up globals once all usages are gone. If you delete the final plugin using NNG, `nng_fini` is called. If you then launch a new plugin, the sockets are unresponsive.
**Fix**: Don't bother with `NngSelfRegister` and `nng_fini` - it's not necessary anyway: https://github.com/nanomsg/nng/blob/722bf4621703ef238fa81018f8c3e68bcef91354/include/nng/nng.h#L211 . I attempted to let the extension handle the `nng_fini` call, but you can't guarantee destruction order of extension and plugins, so can get some nasty crashes - just keep it simple and don't use `nng_fini` at all.

## Render Dialog Fixes

**Problem**: Getting a crash deep down in `free()` sometimes on windows when exiting REAPER. Long-term problem but hasn't caused any real problem since it's on exit.
**Issue**: Came down to the overly complex singleton pattern in render dialog code. 
**Fix**: Didn't bother figuring out why it wasn't working - just replaced with a much simpler pattern which fixed it anyway.

**Problem**: Tested with REAPER v6.58 and there are some new Render options not applicable to OBA. They needed disabling.
**Fix**: Disable options using existing control look-up code and OS API (or via SWELL) calls.
 