### PR TITLE
Custom AudioObject names

### DIFF
--- a/ear-production-suite-plugins/lib/CMakeLists.txt
+++ b/ear-production-suite-plugins/lib/CMakeLists.txt
@@ -81,6 +81,7 @@ set(EAR_BASE_HEADERS
 	include/detail/named_type.hpp
 	include/detail/spdl_nng_sink.hpp
 	include/direct_speakers_backend.hpp
+	include/hoa_backend.hpp
 	include/helper/eps_to_ear_metadata_converter.hpp
 	include/helper/move.hpp
 	include/helper/weak_ptr.hpp
@@ -125,6 +126,7 @@ set(EAR_BASE_HEADERS
 	include/scene_gains_calculator.hpp
 	include/ui/binaural_monitoring_frontend_backend_connector.hpp
 	include/ui/direct_speakers_frontend_backend_connector.hpp
+	include/ui/hoa_frontend_backend_connector.hpp
 	include/ui/item_colour.hpp
 	include/ui/object_frontend_backend_connector.hpp
 	include/variable_block_adapter.hpp

--- a/ear-production-suite-plugins/lib/include/ui/direct_speakers_frontend_backend_connector.hpp
+++ b/ear-production-suite-plugins/lib/include/ui/direct_speakers_frontend_backend_connector.hpp
@@ -33,6 +33,7 @@ class EAR_PLUGIN_BASE_EXPORT DirectSpeakersFrontendBackendConnector {
     NAME,
     COLOUR,
     PACKFORMAT_ID_VALUE,
+    USE_TRACK_NAME,
   };
 
   using ParameterChangedCallback =

--- a/ear-production-suite-plugins/lib/include/ui/hoa_frontend_backend_connector.hpp
+++ b/ear-production-suite-plugins/lib/include/ui/hoa_frontend_backend_connector.hpp
@@ -28,7 +28,7 @@ class EAR_PLUGIN_BASE_EXPORT HoaFrontendBackendConnector {
  public:
   using ParameterValue = boost::variant<float, bool, int, uint32_t,
                                         boost::optional<float>, std::string>;
-  enum class ParameterId { ROUTING, NAME, COLOUR, PACKFORMAT_ID_FORMAT };
+  enum class ParameterId { ROUTING, NAME, COLOUR, PACKFORMAT_ID_FORMAT, USE_TRACK_NAME, };
 
   using ParameterChangedCallback =
       std::function<void(ParameterId, ParameterValue)>;

--- a/ear-production-suite-plugins/lib/include/ui/object_frontend_backend_connector.hpp
+++ b/ear-production-suite-plugins/lib/include/ui/object_frontend_backend_connector.hpp
@@ -42,6 +42,7 @@ class EAR_PLUGIN_BASE_EXPORT ObjectsFrontendBackendConnector {
     DIFFUSE,
     FACTOR,
     RANGE,
+    USE_TRACK_NAME,
   };
 
   using ParameterChangedCallback =

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_component.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_component.hpp
@@ -114,7 +114,7 @@ class DirectSpeakersComponent : public Component,
     auto rightColumn = area.withTrimmedLeft(area.getWidth() / 2);
 
     // left column
-    mainValueBox->setBounds(leftColumn.removeFromTop(197).reduced(5, 5));
+    mainValueBox->setBounds(leftColumn.removeFromTop(223).reduced(5, 5));
     channelMetersBox->setBounds(leftColumn.reduced(5, 5));
 
     // right column

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -103,6 +103,11 @@ void DirectSpeakersJuceFrontendConnector::setName(const std::string& name) {
     nameTextEditorLocked->setText(name);
   }
   cachedName_ = name;
+  // Normally we'd set a processor parameter which in turn calls
+  //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
+  //   which in turns fires notifyParameterChanged.
+  // Instead, we must do that directly (name state not held by a parameter)
+  notifyParameterChanged(ParameterId::NAME, cachedName_);
 }
 
 void DirectSpeakersJuceFrontendConnector::setUseTrackName(bool useTrackName)
@@ -298,11 +303,6 @@ void DirectSpeakersJuceFrontendConnector::textEditorTextChanged(TextEditor& text
 {
   if (auto nameTextEditor = lockIfSame(nameTextEditor_, &textEditor)) {
     setName(nameTextEditor->getText().toStdString());
-    // Normally we'd set a processor parameter which in turn calls
-    //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
-    //   which in turns fires notifyParameterChanged.
-    // Instead, we must do that directly (name state not held by a parameter)
-    notifyParameterChanged(ParameterId::NAME, cachedName_);
   }
 }
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -87,6 +87,7 @@ void DirectSpeakersJuceFrontendConnector::setNameTextEditor(
   textEditor->addListener(this);
   nameTextEditor_ = textEditor;
   setName(cachedName_);
+  updateNameTextEditorState();
 }
 
 void DirectSpeakersJuceFrontendConnector::setUseTrackNameCheckbox(
@@ -94,6 +95,7 @@ void DirectSpeakersJuceFrontendConnector::setUseTrackNameCheckbox(
   useTrackNameCheckbox->addListener(this);
   useTrackNameCheckbox_ = useTrackNameCheckbox;
   setUseTrackName(cachedUseTrackName_);
+  updateNameTextEditorState();
 }
 
 void DirectSpeakersJuceFrontendConnector::setName(const std::string& name) {
@@ -114,20 +116,13 @@ void DirectSpeakersJuceFrontendConnector::setUseTrackName(bool useTrackName)
       useTrackNameCheckboxLocked->setToggleState(useTrackName, dontSendNotification);
       if(useTrackName) {
         lastKnownCustomName_ = cachedName_;
-        nameTextEditorLocked->setEnabled(false);
-        nameTextEditorLocked->setAlpha(0.38f);
-        setName(lastKnownTrackName_);
       } else {
         lastKnownTrackName_ = cachedName_;
-        nameTextEditorLocked->setEnabled(true);
-        nameTextEditorLocked->setAlpha(1.f);
-        if(!lastKnownCustomName_.empty()) {
-          setName(lastKnownCustomName_);
-        }
       }
     }
   }
   cachedUseTrackName_ = useTrackName;
+  updateNameTextEditorState();
 }
 
 void DirectSpeakersJuceFrontendConnector::setColourComboBox(
@@ -308,6 +303,24 @@ void DirectSpeakersJuceFrontendConnector::textEditorTextChanged(TextEditor& text
     //   which in turns fires notifyParameterChanged.
     // Instead, we must do that directly (name state not held by a parameter)
     notifyParameterChanged(ParameterId::NAME, cachedName_);
+  }
+}
+
+void DirectSpeakersJuceFrontendConnector::updateNameTextEditorState()
+{
+  auto nameTextEditorLocked = nameTextEditor_.lock();
+  if(nameTextEditorLocked) {
+    if(cachedUseTrackName_) {
+      nameTextEditorLocked->setEnabled(false);
+      nameTextEditorLocked->setAlpha(0.38f);
+      setName(lastKnownTrackName_);
+    } else {
+      nameTextEditorLocked->setEnabled(true);
+      nameTextEditorLocked->setAlpha(1.f);
+      if(!lastKnownCustomName_.empty()) {
+        setName(lastKnownCustomName_);
+      }
+    }
   }
 }
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.hpp
@@ -18,6 +18,8 @@ class DirectSpeakersJuceFrontendConnector
     : public ear::plugin::ui::DirectSpeakersFrontendBackendConnector,
       private AudioProcessorParameter::Listener,
       Slider::Listener,
+      TextEditor::Listener,
+      Button::Listener,
       ear::plugin::ui::EarComboBox::Listener {
  public:
   /**
@@ -38,6 +40,7 @@ class DirectSpeakersJuceFrontendConnector
   void setStatusBarLabel(std::shared_ptr<Label> label);
   void setColourComboBox(std::shared_ptr<EarComboBox> comboBox);
   void setNameTextEditor(std::shared_ptr<EarNameTextEditor> textEditor);
+  void setUseTrackNameCheckbox(std::shared_ptr<ToggleButton> useTrackNameCheckbox);
   void setRoutingComboBox(std::shared_ptr<EarComboBox> comboBox);
   void setSpeakerSetupsComboBox(std::shared_ptr<EarComboBox> comboBox);
   void setUpperLayerValueBox(std::shared_ptr<ValueBoxSpeakerLayer> layer);
@@ -46,10 +49,12 @@ class DirectSpeakersJuceFrontendConnector
 
   void setName(const std::string& name);
   void setColour(Colour colour);
-
+  void setUseTrackName(bool value);
   void setRouting(int routing);
   void setSpeakerSetup(int speakerSetupIndex);
   void setChannelGainsValueBox(std::shared_ptr<ChannelMeterLayout> gains);
+
+  std::string getActiveName();
 
  protected:
   // ear::plugin::ui::InputFrontendBackendConnector
@@ -64,6 +69,12 @@ class DirectSpeakersJuceFrontendConnector
   void comboBoxChanged(
       ear::plugin::ui::EarComboBox* comboBoxThatHasChanged) override;
 
+  // Button::Listener
+  void buttonClicked(Button*) override;
+
+  //TextEditor::Listener
+  void textEditorTextChanged(TextEditor&) override;
+
  private:
   void speakerSetupChanged(int index);
 
@@ -76,7 +87,11 @@ class DirectSpeakersJuceFrontendConnector
   std::weak_ptr<Label> statusBarLabel_;
   std::string cachedStatusBarText_;
   std::weak_ptr<EarNameTextEditor> nameTextEditor_;
+  std::weak_ptr<ToggleButton> useTrackNameCheckbox_;
   std::string cachedName_{};
+  std::string lastKnownTrackName_{};
+  std::string lastKnownCustomName_{};
+  bool cachedUseTrackName_{ true };
   std::weak_ptr<EarComboBox> colourComboBox_;
   Colour cachedColour_{ juce::Colours::transparentBlack };
   std::weak_ptr<EarComboBox> routingComboBox_;

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.hpp
@@ -76,7 +76,7 @@ class DirectSpeakersJuceFrontendConnector
   void textEditorTextChanged(TextEditor&) override;
 
  private:
-  void updateNameTextEditorState();
+  void updateNameState();
 
   DirectSpeakersAudioProcessor* p_;
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.hpp
@@ -76,7 +76,7 @@ class DirectSpeakersJuceFrontendConnector
   void textEditorTextChanged(TextEditor&) override;
 
  private:
-  void speakerSetupChanged(int index);
+  void updateNameTextEditorState();
 
   DirectSpeakersAudioProcessor* p_;
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_editor.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_editor.cpp
@@ -22,6 +22,8 @@ DirectSpeakersAudioProcessorEditor::DirectSpeakersAudioProcessorEditor(
   p->getFrontendConnector()->setStatusBarLabel(content_->statusBarLabel);
   p->getFrontendConnector()->setNameTextEditor(
       content_->mainValueBox->getNameTextEditor());
+  p->getFrontendConnector()->setUseTrackNameCheckbox(
+      content_->mainValueBox->getUseTrackNameCheckbox());
   p->getFrontendConnector()->setColourComboBox(
       content_->mainValueBox->getColourComboBox());
   p->getFrontendConnector()->setRoutingComboBox(

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
@@ -24,8 +24,10 @@ DirectSpeakersAudioProcessor::DirectSpeakersAudioProcessor()
     new ui::NonAutomatedParameter<AudioParameterInt>(
       "packFormatIdValue", "PackFormat ID Value",
       0x0, 0xFFFF, 0));
-
-  addParameter(bypass_ = new AudioParameterBool("byps", "Bypass", false));
+  addParameter(bypass_ =
+    new AudioParameterBool("byps", "Bypass", false));
+  addParameter(useTrackName_ =
+    new AudioParameterBool("useTrackName", "Use Track Name", true));
   /* clang-format on */
 
   static_cast<ui::NonAutomatedParameter<AudioParameterInt>*>(routing_)->markPluginStateAsDirty = [this]() {
@@ -41,6 +43,7 @@ DirectSpeakersAudioProcessor::DirectSpeakersAudioProcessor()
 
   connector_->parameterValueChanged(0, routing_->get());
   connector_->parameterValueChanged(1, packFormatIdValue_->get());
+  connector_->parameterValueChanged(3, useTrackName_->get());
 }
 
 DirectSpeakersAudioProcessor::~DirectSpeakersAudioProcessor() {}
@@ -113,6 +116,8 @@ void DirectSpeakersAudioProcessor::getStateInformation(MemoryBlock& destData) {
   xml->setAttribute("connection_id", connectionId_.string());
   xml->setAttribute("routing", (int)*routing_);
   xml->setAttribute("packformat_id_value", (int)*packFormatIdValue_);
+  xml->setAttribute("use_track_name", (bool)*useTrackName_);
+  xml->setAttribute("name", connector_->getActiveName());
   copyXmlToBinary(*xml, destData);
 }
 
@@ -143,6 +148,9 @@ void DirectSpeakersAudioProcessor::setStateInformation(const void* data,
           *packFormatIdValue_ = 0;
         }
       }
+
+      *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
+      connector_->setName(xmlState->getStringAttribute("name", "No Name").toStdString());
     }
 }
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.hpp
@@ -51,6 +51,7 @@ class DirectSpeakersAudioProcessor : public AudioProcessor {
 
   AudioParameterInt* getRouting() { return routing_; }
   AudioParameterInt* getPackFormatIdValue() { return packFormatIdValue_; }
+  AudioParameterBool* getUseTrackName() { return useTrackName_; }
 
   AudioProcessorParameter* getBypassParameter() {
     return bypass_;
@@ -70,6 +71,7 @@ class DirectSpeakersAudioProcessor : public AudioProcessor {
   AudioParameterInt* routing_;
   AudioParameterInt* packFormatIdValue_;
   AudioParameterBool* bypass_;
+  AudioParameterBool* useTrackName_;
 
   std::unique_ptr<ear::plugin::ui::DirectSpeakersJuceFrontendConnector>
       connector_;

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/value_box_main.hpp
@@ -16,15 +16,20 @@ class ValueBoxMain : public Component {
   ValueBoxMain()
       : colourComboBox_(std::make_shared<EarComboBox>()),
         name_(std::make_shared<EarNameTextEditor>()),
+        useTrackNameCheckbox_(std::make_shared<ToggleButton>()),
         speakerSetupLabel_(std::make_unique<Label>()),
         speakerSetupsComboBox_(std::make_shared<EarComboBox>()),
         routingLabel_(std::make_unique<Label>()),
         routingComboBox_(std::make_shared<EarComboBox>()) {
-    name_->setLabelText("Name");
+    name_->setLabelText("Object Name");
     name_->setText("Object_1");
     name_->setEnabled(false);
     name_->setAlpha(0.38f);
     addAndMakeVisible(name_.get());
+
+    useTrackNameCheckbox_->setButtonText("Use track name");
+    useTrackNameCheckbox_->setClickingTogglesState(false); // FrontendConnector controls state
+    addAndMakeVisible(useTrackNameCheckbox_.get());
 
     routingLabel_->setFont(EarFonts::Label);
     routingLabel_->setText("Routing",
@@ -68,12 +73,12 @@ class ValueBoxMain : public Component {
 
     area.removeFromTop(marginBig_);
 
-    auto descArea = area.removeFromTop(63);
+    auto descArea = area.removeFromTop(90);
     auto colourArea = descArea.withWidth(labelWidth_);
-    colourComboBox_->setBounds(colourArea);
-    auto nameArea = descArea.withTrimmedLeft(labelWidth_ + marginBig_)
-                        .reduced(0, marginSmall_);
-    name_->setBounds(nameArea);
+    colourComboBox_->setBounds(colourArea.removeFromTop(63));
+    auto nameArea = descArea.withTrimmedLeft(labelWidth_ + marginBig_);
+    name_->setBounds(nameArea.removeFromTop(63).reduced(0, marginSmall_));
+    useTrackNameCheckbox_->setBounds(nameArea);
 
     area.removeFromTop(15.f);
 
@@ -95,6 +100,7 @@ class ValueBoxMain : public Component {
   }
 
   std::shared_ptr<EarNameTextEditor> getNameTextEditor() { return name_; }
+  std::shared_ptr<ToggleButton> getUseTrackNameCheckbox() { return useTrackNameCheckbox_; }
   std::shared_ptr<EarComboBox> getRoutingComboBox() { return routingComboBox_; }
   std::shared_ptr<EarComboBox> getColourComboBox() { return colourComboBox_; }
   std::shared_ptr<EarComboBox> getSpeakerSetupsComboBox() {
@@ -113,6 +119,7 @@ class ValueBoxMain : public Component {
   std::shared_ptr<EarComboBox> speakerSetupsComboBox_;
   std::unique_ptr<Label> routingLabel_;
   std::shared_ptr<EarComboBox> routingComboBox_;
+  std::shared_ptr<ToggleButton> useTrackNameCheckbox_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ValueBoxMain)
 };

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_component.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_component.hpp
@@ -95,13 +95,11 @@ class HoaComponent : public Component,
         headingArea.removeFromRight(39).removeFromBottom(39));
     header->setBounds(headingArea);
 
-    auto leftColumn = area.withTrimmedRight(area.getWidth() / 2);
-    auto rightColumn = area.withTrimmedLeft(area.getWidth() / 2);
-    auto orderDisplayArea = area.withTrimmedTop(197);
-
-    mainValueBox->setBounds(leftColumn.removeFromTop(197).reduced(5, 5));
-
-    orderDisplayValueBox->setBounds(orderDisplayArea.reduced(5, 5));
+    auto topArea = area.removeFromTop(223);
+    auto leftColumn = topArea.withTrimmedRight(area.getWidth() / 2);
+    auto rightColumn = topArea.withTrimmedLeft(area.getWidth() / 2);
+    mainValueBox->setBounds(leftColumn.reduced(5, 5));
+    orderDisplayValueBox->setBounds(area.reduced(5, 5));
   }
 
   std::unique_ptr<EarHeader> header;

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
@@ -81,6 +81,7 @@ void HoaJuceFrontendConnector::setNameTextEditor(
   textEditor->addListener(this);
   nameTextEditor_ = textEditor;
   setName(cachedName_);
+  updateNameTextEditorState();
 }
 
 void HoaJuceFrontendConnector::setUseTrackNameCheckbox(
@@ -88,6 +89,7 @@ void HoaJuceFrontendConnector::setUseTrackNameCheckbox(
   useTrackNameCheckbox->addListener(this);
   useTrackNameCheckbox_ = useTrackNameCheckbox;
   setUseTrackName(cachedUseTrackName_);
+  updateNameTextEditorState();
 }
 
 void HoaJuceFrontendConnector::setName(const std::string& name) {
@@ -108,20 +110,13 @@ void HoaJuceFrontendConnector::setUseTrackName(bool useTrackName)
       useTrackNameCheckboxLocked->setToggleState(useTrackName, dontSendNotification);
       if(useTrackName) {
         lastKnownCustomName_ = cachedName_;
-        nameTextEditorLocked->setEnabled(false);
-        nameTextEditorLocked->setAlpha(0.38f);
-        setName(lastKnownTrackName_);
       } else {
         lastKnownTrackName_ = cachedName_;
-        nameTextEditorLocked->setEnabled(true);
-        nameTextEditorLocked->setAlpha(1.f);
-        if(!lastKnownCustomName_.empty()) {
-          setName(lastKnownCustomName_);
-        }
       }
     }
   }
   cachedUseTrackName_ = useTrackName;
+  updateNameTextEditorState();
 }
 
 void HoaJuceFrontendConnector::setColourComboBox(
@@ -267,6 +262,24 @@ void HoaJuceFrontendConnector::textEditorTextChanged(TextEditor& textEditor)
     //   which in turns fires notifyParameterChanged.
     // Instead, we must do that directly (name state not held by a parameter)
     notifyParameterChanged(ParameterId::NAME, cachedName_);
+  }
+}
+
+void HoaJuceFrontendConnector::updateNameTextEditorState()
+{
+  auto nameTextEditorLocked = nameTextEditor_.lock();
+  if(nameTextEditorLocked) {
+    if(cachedUseTrackName_) {
+      nameTextEditorLocked->setEnabled(false);
+      nameTextEditorLocked->setAlpha(0.38f);
+      setName(lastKnownTrackName_);
+    } else {
+      nameTextEditorLocked->setEnabled(true);
+      nameTextEditorLocked->setAlpha(1.f);
+      if(!lastKnownCustomName_.empty()) {
+        setName(lastKnownCustomName_);
+      }
+    }
   }
 }
 

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
@@ -97,6 +97,11 @@ void HoaJuceFrontendConnector::setName(const std::string& name) {
     nameTextEditorLocked->setText(name);
   }
   cachedName_ = name;
+  // Normally we'd set a processor parameter which in turn calls
+  //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
+  //   which in turns fires notifyParameterChanged.
+  // Instead, we must do that directly (name state not held by a parameter)
+  notifyParameterChanged(ParameterId::NAME, cachedName_);
 }
 
 void HoaJuceFrontendConnector::setUseTrackName(bool useTrackName)
@@ -257,11 +262,6 @@ void HoaJuceFrontendConnector::textEditorTextChanged(TextEditor& textEditor)
 {
   if (auto nameTextEditor = lockIfSame(nameTextEditor_, &textEditor)) {
     setName(nameTextEditor->getText().toStdString());
-    // Normally we'd set a processor parameter which in turn calls
-    //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
-    //   which in turns fires notifyParameterChanged.
-    // Instead, we must do that directly (name state not held by a parameter)
-    notifyParameterChanged(ParameterId::NAME, cachedName_);
   }
 }
 

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.hpp
@@ -18,6 +18,8 @@ class ValueBoxOrderDisplay;
 class HoaJuceFrontendConnector
     : public ear::plugin::ui::HoaFrontendBackendConnector,
       private AudioProcessorParameter::Listener,
+      TextEditor::Listener,
+      Button::Listener,
       ear::plugin::ui::EarComboBox::Listener {
  public:
   /**
@@ -37,20 +39,30 @@ class HoaJuceFrontendConnector
   void setStatusBarLabel(std::shared_ptr<Label> label);
   void setColourComboBox(std::shared_ptr<EarComboBox> comboBox);
   void setNameTextEditor(std::shared_ptr<EarNameTextEditor> textEditor);
+  void setUseTrackNameCheckbox(std::shared_ptr<ToggleButton> useTrackNameCheckbox);
   void setRoutingComboBox(std::shared_ptr<EarComboBox> comboBox);
   void setHoaTypeComboBox(std::shared_ptr<EarComboBox> comboBox);
   void setOrderDisplayValueBox(std::shared_ptr<ValueBoxOrderDisplay> gains);
 
   void setName(const std::string& name);
   void setColour(Colour colour);
+  void setUseTrackName(bool value);
   void setRouting(int routing);
   void setHoaType(int hoaType);
+
+  std::string getActiveName();
 
  protected:
   void doSetStatusBarText(const std::string& text) override;
 
   void comboBoxChanged(
       ear::plugin::ui::EarComboBox* comboBoxThatHasChanged) override;
+
+  // Button::Listener
+  void buttonClicked(Button*) override;
+
+  //TextEditor::Listener
+  void textEditorTextChanged(TextEditor&) override;
 
  private:
   HoaAudioProcessor* p_;
@@ -63,7 +75,11 @@ class HoaJuceFrontendConnector
   std::string cachedStatusBarText_;
 
   std::weak_ptr<EarNameTextEditor> nameTextEditor_;
+  std::weak_ptr<ToggleButton> useTrackNameCheckbox_;
   std::string cachedName_;
+  std::string lastKnownTrackName_{};
+  std::string lastKnownCustomName_{};
+  bool cachedUseTrackName_{ true };
   std::weak_ptr<EarComboBox> colourComboBox_;
   Colour cachedColour_;
   std::weak_ptr<EarComboBox> routingComboBox_;

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.hpp
@@ -65,7 +65,7 @@ class HoaJuceFrontendConnector
   void textEditorTextChanged(TextEditor&) override;
 
  private:
-  void updateNameTextEditorState();
+  void updateNameState();
 
   HoaAudioProcessor* p_;
 

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.hpp
@@ -65,6 +65,8 @@ class HoaJuceFrontendConnector
   void textEditorTextChanged(TextEditor&) override;
 
  private:
+  void updateNameTextEditorState();
+
   HoaAudioProcessor* p_;
 
   MultiAsyncUpdater updater_;

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_editor.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_editor.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 const int desiredWidth{800};
-const int desiredHeight{650};
+const int desiredHeight{677};
 }  // namespace
 
 using namespace ear::plugin::ui;
@@ -17,9 +17,12 @@ HoaAudioProcessorEditor::HoaAudioProcessorEditor(HoaAudioProcessor* p)
       p_(p),
       content_(std::make_unique<HoaComponent>(p)),
       viewport_(std::make_unique<Viewport>()) {
-  p->getFrontendConnector()->setStatusBarLabel(content_->statusBarLabel);
+  p->getFrontendConnector()->setStatusBarLabel(
+      content_->statusBarLabel);
   p->getFrontendConnector()->setNameTextEditor(
       content_->mainValueBox->getNameTextEditor());
+  p->getFrontendConnector()->setUseTrackNameCheckbox(
+      content_->mainValueBox->getUseTrackNameCheckbox());
   p->getFrontendConnector()->setColourComboBox(
       content_->mainValueBox->getColourComboBox());
   p->getFrontendConnector()->setRoutingComboBox(

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
@@ -25,7 +25,10 @@ HoaAudioProcessor::HoaAudioProcessor()
     new ui::NonAutomatedParameter<AudioParameterInt>(
       "packformat_id_value", "PackFormat ID Value",
       0, 0xFFFF, 0));
-  addParameter(bypass_ = new AudioParameterBool("byps", "Bypass", false));
+  addParameter(bypass_ =
+    new AudioParameterBool("byps", "Bypass", false));
+  addParameter(useTrackName_ =
+    new AudioParameterBool("useTrackName", "Use Track Name", true));
   /* clang-format on */
 
   static_cast<ui::NonAutomatedParameter<AudioParameterInt>*>(routing_)
@@ -46,6 +49,7 @@ HoaAudioProcessor::HoaAudioProcessor()
 
   connector_->parameterValueChanged(0, routing_->get());
   connector_->parameterValueChanged(1, packFormatIdValue_->get());
+  connector_->parameterValueChanged(3, useTrackName_->get());
 }
 
 HoaAudioProcessor::~HoaAudioProcessor() {}
@@ -110,7 +114,8 @@ void HoaAudioProcessor::getStateInformation(MemoryBlock& destData) {
   xml->setAttribute("connection_id", connectionId_.string());
   xml->setAttribute("routing", (int)*routing_);
   xml->setAttribute("packformat_id_value", (int)*packFormatIdValue_);
-
+  xml->setAttribute("use_track_name", (bool)*useTrackName_);
+  xml->setAttribute("name", connector_->getActiveName());
   copyXmlToBinary(*xml, destData);
 }
 
@@ -127,6 +132,8 @@ void HoaAudioProcessor::setStateInformation(const void* data, int sizeInBytes) {
       auto con_id = connectionId_;
       *routing_ = xmlState->getIntAttribute("routing", -1);
       *packFormatIdValue_ = xmlState->getIntAttribute("packformat_id_value", 0);
+      *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
+      connector_->setName(xmlState->getStringAttribute("name", "No Name").toStdString());
     }
 }
 

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.hpp
@@ -53,6 +53,7 @@ class HoaAudioProcessor : public AudioProcessor {
 
   AudioParameterInt* getRouting() { return routing_; }
   AudioParameterInt* getPackFormatIdValue() { return packFormatIdValue_; }
+  AudioParameterBool* getUseTrackName() { return useTrackName_; }
 
   AudioProcessorParameter* getBypassParameter() { return bypass_; }
 
@@ -70,6 +71,7 @@ class HoaAudioProcessor : public AudioProcessor {
   AudioParameterInt* routing_;
   AudioParameterInt* packFormatIdValue_;
   AudioParameterBool* bypass_;
+  AudioParameterBool* useTrackName_;
 
   std::unique_ptr<ear::plugin::ui::HoaJuceFrontendConnector> connector_;
   std::unique_ptr<ear::plugin::HoaBackend> backend_;

--- a/ear-production-suite-plugins/plugins/hoa/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/value_box_main.hpp
@@ -15,6 +15,7 @@ class ValueBoxMain : public Component {
   ValueBoxMain()
       : colourComboBox_(std::make_shared<EarComboBox>()),
         name_(std::make_shared<EarNameTextEditor>()),
+        useTrackNameCheckbox_(std::make_shared<ToggleButton>()),
         hoaTypeLabel_(std::make_unique<Label>()),
         hoaTypeComboBox_(std::make_shared<EarComboBox>()),
         routingLabel_(std::make_unique<Label>()),
@@ -27,11 +28,15 @@ class ValueBoxMain : public Component {
     routingLabel_->setName("Label (ValueBoxMain::routingLabel_)");
     routingComboBox_->setName("EarComboBox (ValueBoxMain::routingComboBox_)");
 
-    name_->setLabelText("Name");
+    name_->setLabelText("Object Name");
     name_->setText("HOA_1");
     name_->setEnabled(false);
     name_->setAlpha(0.38f);
     addAndMakeVisible(name_.get());
+
+    useTrackNameCheckbox_->setButtonText("Use track name");
+    useTrackNameCheckbox_->setClickingTogglesState(false); // FrontendConnector controls state
+    addAndMakeVisible(useTrackNameCheckbox_.get());
 
     routingLabel_->setFont(EarFonts::Label);
     routingLabel_->setText("Routing",
@@ -84,12 +89,12 @@ class ValueBoxMain : public Component {
 
     area.removeFromTop(marginBig_);
 
-    auto descArea = area.removeFromTop(63);
+    auto descArea = area.removeFromTop(90);
     auto colourArea = descArea.withWidth(labelWidth_);
-    colourComboBox_->setBounds(colourArea);
-    auto nameArea = descArea.withTrimmedLeft(labelWidth_ + marginBig_)
-                        .reduced(0, marginSmall_);
-    name_->setBounds(nameArea);
+    colourComboBox_->setBounds(colourArea.removeFromTop(63));
+    auto nameArea = descArea.withTrimmedLeft(labelWidth_ + marginBig_);
+    name_->setBounds(nameArea.removeFromTop(63).reduced(0, marginSmall_));
+    useTrackNameCheckbox_->setBounds(nameArea);
 
     area.removeFromTop(15.f);
 
@@ -114,6 +119,7 @@ class ValueBoxMain : public Component {
   std::shared_ptr<EarComboBox> getRoutingComboBox() { return routingComboBox_; }
   std::shared_ptr<EarComboBox> getColourComboBox() { return colourComboBox_; }
   std::shared_ptr<EarComboBox> getHoaTypeComboBox() { return hoaTypeComboBox_; }
+  std::shared_ptr<ToggleButton> getUseTrackNameCheckbox() { return useTrackNameCheckbox_; }
 
  private:
   const float labelWidth_ = 110.f;
@@ -123,6 +129,7 @@ class ValueBoxMain : public Component {
 
   std::shared_ptr<EarComboBox> colourComboBox_;
   std::shared_ptr<EarNameTextEditor> name_;
+  std::shared_ptr<ToggleButton> useTrackNameCheckbox_;
 
   std::unique_ptr<Label> hoaTypeLabel_;
   std::shared_ptr<EarComboBox> hoaTypeComboBox_;

--- a/ear-production-suite-plugins/plugins/object/src/object_component.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_component.hpp
@@ -127,7 +127,7 @@ class ObjectsComponent : public Component,
     auto rightColumn = area.withTrimmedLeft(area.getWidth() / 2);
 
     // left column
-    mainValueBox->setBounds(leftColumn.removeFromTop(161).reduced(5, 5));
+    mainValueBox->setBounds(leftColumn.removeFromTop(187).reduced(5, 5));
     gainValueBox->setBounds(leftColumn.removeFromTop(103).reduced(5, 5));
     // TODO - panningValueBox original position - reinstate when metadata implemented
     //panningValueBox->setBounds(leftColumn.removeFromTop(219).reduced(5, 5));

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
@@ -277,6 +277,11 @@ void ObjectsJuceFrontendConnector::setName(const std::string& name) {
     nameTextEditorLocked->setText(name);
   }
   cachedName_ = name;
+  // Normally we'd set a processor parameter which in turn calls
+  //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
+  //   which in turns fires notifyParameterChanged.
+  // Instead, we must do that directly (name state not held by a parameter)
+  notifyParameterChanged(ParameterId::NAME, cachedName_);
 }
 
 void ObjectsJuceFrontendConnector::setUseTrackName(bool useTrackName)
@@ -765,11 +770,6 @@ void ObjectsJuceFrontendConnector::textEditorTextChanged(TextEditor& textEditor)
 {
   if (auto nameTextEditor = lockIfSame(nameTextEditor_, &textEditor)) {
     setName(nameTextEditor->getText().toStdString());
-    // Normally we'd set a processor parameter which in turn calls
-    //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
-    //   which in turns fires notifyParameterChanged.
-    // Instead, we must do that directly (name state not held by a parameter)
-    notifyParameterChanged(ParameterId::NAME, cachedName_);
   }
 }
 

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
@@ -744,8 +744,17 @@ void ObjectsJuceFrontendConnector::textEditorTextChanged(TextEditor& textEditor)
 {
   if (auto nameTextEditor = lockIfSame(nameTextEditor_, &textEditor)) {
     setName(nameTextEditor->getText().toStdString());
+    // Normally we'd set a processor parameter which in turn calls
+    //   ObjectsJuceFrontendConnector::parameterValueChanged as a listener,
+    //   which in turns fires notifyParameterChanged.
+    // Instead, we must do that directly (name state not held by a parameter)
     notifyParameterChanged(ParameterId::NAME, cachedName_);
   }
+}
+
+std::string ObjectsJuceFrontendConnector::getActiveName()
+{
+  return cachedName_;
 }
 
 }  // namespace ui

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
@@ -118,6 +118,7 @@ void ObjectsJuceFrontendConnector::setNameTextEditor(
   textEditor->addListener(this);
   nameTextEditor_ = textEditor;
   setName(cachedName_);
+  updateNameTextEditorState();
 }
 
 void ObjectsJuceFrontendConnector::setUseTrackNameCheckbox(
@@ -125,6 +126,7 @@ void ObjectsJuceFrontendConnector::setUseTrackNameCheckbox(
   useTrackNameCheckbox->addListener(this);
   useTrackNameCheckbox_ = useTrackNameCheckbox;
   setUseTrackName(cachedUseTrackName_);
+  updateNameTextEditorState();
 }
 
 void ObjectsJuceFrontendConnector::setColourComboBox(
@@ -288,20 +290,13 @@ void ObjectsJuceFrontendConnector::setUseTrackName(bool useTrackName)
       useTrackNameCheckboxLocked->setToggleState(useTrackName, dontSendNotification);
       if(useTrackName) {
         lastKnownCustomName_ = cachedName_;
-        nameTextEditorLocked->setEnabled(false);
-        nameTextEditorLocked->setAlpha(0.38f);
-        setName(lastKnownTrackName_);
       } else {
         lastKnownTrackName_ = cachedName_;
-        nameTextEditorLocked->setEnabled(true);
-        nameTextEditorLocked->setAlpha(1.f);
-        if(!lastKnownCustomName_.empty()) {
-          setName(lastKnownCustomName_);
-        }
       }
     }
   }
   cachedUseTrackName_ = useTrackName;
+  updateNameTextEditorState();
 }
 
 void ObjectsJuceFrontendConnector::setColour(Colour colour) {
@@ -635,6 +630,24 @@ void ObjectsJuceFrontendConnector::sliderDragStarted(Slider* slider) {
 
 void ObjectsJuceFrontendConnector::sliderDragEnded(Slider* slider) {
   dispatchSliderAction(slider, SliderAction::DRAG_END);
+}
+
+void ObjectsJuceFrontendConnector::updateNameTextEditorState()
+{
+  auto nameTextEditorLocked = nameTextEditor_.lock();
+  if(nameTextEditorLocked) {
+    if(cachedUseTrackName_) {
+      nameTextEditorLocked->setEnabled(false);
+      nameTextEditorLocked->setAlpha(0.38f);
+      setName(lastKnownTrackName_);
+    } else {
+      nameTextEditorLocked->setEnabled(true);
+      nameTextEditorLocked->setAlpha(1.f);
+      if(!lastKnownCustomName_.empty()) {
+        setName(lastKnownCustomName_);
+      }
+    }
+  }
 }
 
 void ObjectsJuceFrontendConnector::dispatchSliderAction(Slider* slider, SliderAction action) {

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.cpp
@@ -115,6 +115,7 @@ void ObjectsJuceFrontendConnector::doSetStatusBarText(const std::string& text) {
 
 void ObjectsJuceFrontendConnector::setNameTextEditor(
     std::shared_ptr<EarNameTextEditor> textEditor) {
+  textEditor->addListener(this);
   nameTextEditor_ = textEditor;
   setName(cachedName_);
 }
@@ -284,9 +285,9 @@ void ObjectsJuceFrontendConnector::setUseTrackName(bool useTrackName)
   if (useTrackNameCheckboxLocked && nameTextEditorLocked) {
     useTrackNameCheckboxLocked->setToggleState(useTrackName, dontSendNotification);
     if (useTrackName) {
-      nameTextEditorLocked->setText(lastReceivedTrackName_);
       nameTextEditorLocked->setEnabled(false);
       nameTextEditorLocked->setAlpha(0.38f);
+      setName(lastReceivedTrackName_);
     } else {
       nameTextEditorLocked->setEnabled(true);
       nameTextEditorLocked->setAlpha(1.f);
@@ -736,6 +737,14 @@ void ObjectsJuceFrontendConnector::buttonClicked(Button* button) {
     *(p_->getLinkSize()) = !linkSizeButton->getToggleState();
   }  else if (auto useTrackNameCheckbox = lockIfSame(useTrackNameCheckbox_, button)) {
     *(p_->getUseTrackName()) = !useTrackNameCheckbox->getToggleState();
+  }
+}
+
+void ObjectsJuceFrontendConnector::textEditorTextChanged(TextEditor& textEditor)
+{
+  if (auto nameTextEditor = lockIfSame(nameTextEditor_, &textEditor)) {
+    setName(nameTextEditor->getText().toStdString());
+    notifyParameterChanged(ParameterId::NAME, cachedName_);
   }
 }
 

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
@@ -180,7 +180,8 @@ class ObjectsJuceFrontendConnector
   Colour cachedColour_{ juce::Colours::transparentBlack };
   int cachedRouting_{ -1 };
   std::string cachedName_{};
-  std::string lastReceivedTrackName_{};
+  std::string lastKnownTrackName_{};
+  std::string lastKnownCustomName_{};
   bool cachedUseTrackName_{ true };
   float cachedGain_{ 1.f };
   float cachedAzimuth_{ 0.f };

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
@@ -102,6 +102,8 @@ class ObjectsJuceFrontendConnector
   void setFactor(float value);
   void setRange(float value);
 
+  std::string getActiveName();
+
  protected:
   // Slider::Listener
   void sliderValueChanged(Slider* slider) override;

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
@@ -128,6 +128,9 @@ class ObjectsJuceFrontendConnector
   // Button::Listener
   void buttonClicked(Button*) override;
 
+  //TextEditor::Listener
+  void textEditorTextChanged(TextEditor&) override;
+
  private:
 
   void dispatchSliderAction(Slider*, SliderAction action);

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
@@ -134,7 +134,7 @@ class ObjectsJuceFrontendConnector
   void textEditorTextChanged(TextEditor&) override;
 
  private:
-  void updateNameTextEditorState();
+  void updateNameState();
 
   void dispatchSliderAction(Slider*, SliderAction action);
   ObjectsAudioProcessor* p_;

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
@@ -134,6 +134,7 @@ class ObjectsJuceFrontendConnector
   void textEditorTextChanged(TextEditor&) override;
 
  private:
+  void updateNameTextEditorState();
 
   void dispatchSliderAction(Slider*, SliderAction action);
   ObjectsAudioProcessor* p_;

--- a/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_frontend_connector.hpp
@@ -50,6 +50,7 @@ class ObjectsJuceFrontendConnector
   // Main Value Box
   void setStatusBarLabel(std::shared_ptr<Label> statusBarLabel);
   void setNameTextEditor(std::shared_ptr<EarNameTextEditor> nameTextEditor);
+  void setUseTrackNameCheckbox(std::shared_ptr<ToggleButton> useTrackNameCheckbox);
   void setColourComboBox(std::shared_ptr<EarComboBox> colourComboBox);
   void setRoutingComboBox(std::shared_ptr<EarComboBox> routingComboBox);
 
@@ -82,6 +83,7 @@ class ObjectsJuceFrontendConnector
 
   // Value setter
   void setName(const std::string& name);
+  void setUseTrackName(bool value);
   void setColour(Colour colour);
   void setRouting(int routing);
   void setGain(float gain);
@@ -136,6 +138,7 @@ class ObjectsJuceFrontendConnector
   std::weak_ptr<EarComboBox> colourComboBox_;
   std::weak_ptr<EarComboBox> routingComboBox_;
   std::weak_ptr<EarNameTextEditor> nameTextEditor_;
+  std::weak_ptr<ToggleButton> useTrackNameCheckbox_;
 
   // Panning Value Box
   std::weak_ptr<EarSlider> gainSlider_;
@@ -172,6 +175,8 @@ class ObjectsJuceFrontendConnector
   Colour cachedColour_{ juce::Colours::transparentBlack };
   int cachedRouting_{ -1 };
   std::string cachedName_{};
+  std::string lastReceivedTrackName_{};
+  bool cachedUseTrackName_{ true };
   float cachedGain_{ 1.f };
   float cachedAzimuth_{ 0.f };
   float cachedElevation_{ 0.f };

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_editor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_editor.cpp
@@ -18,6 +18,7 @@ ObjectAudioProcessorEditor::ObjectAudioProcessorEditor(ObjectsAudioProcessor* p)
   /* clang-format off */
   p->getFrontendConnector()->setStatusBarLabel(content_->statusBarLabel);
   p->getFrontendConnector()->setNameTextEditor(content_->mainValueBox->getNameTextEditor());
+  p->getFrontendConnector()->setUseTrackNameCheckbox(content_->mainValueBox->getUseTrackNameCheckbox());
   p->getFrontendConnector()->setColourComboBox(content_->mainValueBox->getColourComboBox());
   p->getFrontendConnector()->setRoutingComboBox(content_->mainValueBox->getRoutingComboBox());
 

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
@@ -29,6 +29,7 @@ ObjectsAudioProcessor::ObjectsAudioProcessor()
   addParameter(factor_ = new AudioParameterFloat("factor", "Factor", 0.f, 1.f, 0.f));
   addParameter(range_ = new AudioParameterFloat("range", "Range", 0.f, 180.f, 45.f));
   addParameter(bypass_ = new AudioParameterBool("byps", "Bypass", false));
+  addParameter(useTrackName_ = new AudioParameterBool("useTrackName", "Use Track Name", true));
   /* clang-format on */
 
   static_cast<ui::NonAutomatedParameter<AudioParameterInt>*>(routing_)->markPluginStateAsDirty = [this]() {
@@ -52,6 +53,7 @@ ObjectsAudioProcessor::ObjectsAudioProcessor()
   connector_->parameterValueChanged(11, divergence_->get());
   connector_->parameterValueChanged(12, factor_->get());
   connector_->parameterValueChanged(13, range_->get());
+  connector_->parameterValueChanged(14, useTrackName_->get());
 }
 
 ObjectsAudioProcessor::~ObjectsAudioProcessor() {}
@@ -139,6 +141,7 @@ void ObjectsAudioProcessor::getStateInformation(MemoryBlock& destData) {
   xml->setAttribute("divergence", (bool)*divergence_);
   xml->setAttribute("factor", (double)*factor_);
   xml->setAttribute("range", (double)*range_);
+  xml->setAttribute("use_track_name", (bool)*useTrackName_);
   copyXmlToBinary(*xml, destData);
 }
 
@@ -167,6 +170,7 @@ void ObjectsAudioProcessor::setStateInformation(const void* data,
       *divergence_ = xmlState->getBoolAttribute("divergence", false);
       *factor_ = xmlState->getDoubleAttribute("factor", 0.0);
       *range_ = xmlState->getDoubleAttribute("range", 0.0);
+      *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
     }
   }
 }

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
@@ -142,6 +142,7 @@ void ObjectsAudioProcessor::getStateInformation(MemoryBlock& destData) {
   xml->setAttribute("factor", (double)*factor_);
   xml->setAttribute("range", (double)*range_);
   xml->setAttribute("use_track_name", (bool)*useTrackName_);
+  xml->setAttribute("name", connector_->getActiveName());
   copyXmlToBinary(*xml, destData);
 }
 
@@ -170,7 +171,12 @@ void ObjectsAudioProcessor::setStateInformation(const void* data,
       *divergence_ = xmlState->getBoolAttribute("divergence", false);
       *factor_ = xmlState->getDoubleAttribute("factor", 0.0);
       *range_ = xmlState->getDoubleAttribute("range", 0.0);
-      *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
+      if(xmlState->hasAttribute("use_track_name")) {
+        *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
+      }
+      if(xmlState->hasAttribute("name")) {
+        connector_->setName(xmlState->getStringAttribute("name", "No Name").toStdString());
+      }
     }
   }
 }

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
@@ -171,12 +171,8 @@ void ObjectsAudioProcessor::setStateInformation(const void* data,
       *divergence_ = xmlState->getBoolAttribute("divergence", false);
       *factor_ = xmlState->getDoubleAttribute("factor", 0.0);
       *range_ = xmlState->getDoubleAttribute("range", 0.0);
-      if(xmlState->hasAttribute("use_track_name")) {
-        *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
-      }
-      if(xmlState->hasAttribute("name")) {
-        connector_->setName(xmlState->getStringAttribute("name", "No Name").toStdString());
-      }
+      *useTrackName_ = xmlState->getBoolAttribute("use_track_name", true);
+      connector_->setName(xmlState->getStringAttribute("name", "No Name").toStdString());
     }
   }
 }

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.hpp
@@ -62,6 +62,7 @@ class ObjectsAudioProcessor : public AudioProcessor {
   AudioParameterBool* getDivergence() { return divergence_; }
   AudioParameterFloat* getFactor() { return factor_; }
   AudioParameterFloat* getRange() { return range_; }
+  AudioParameterBool* getUseTrackName() { return useTrackName_; }
 
   AudioProcessorParameter* getBypassParameter() {
     return bypass_;
@@ -93,6 +94,7 @@ class ObjectsAudioProcessor : public AudioProcessor {
   AudioParameterFloat* factor_;
   AudioParameterFloat* range_;
   AudioParameterBool* bypass_;
+  AudioParameterBool* useTrackName_;
 
   std::unique_ptr<ear::plugin::ui::ObjectsJuceFrontendConnector> connector_;
   std::unique_ptr<ear::plugin::ObjectBackend> backend_;

--- a/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
@@ -28,6 +28,7 @@ class ValueBoxMain : public Component {
     addAndMakeVisible(name_.get());
 
     useTrackNameCheckbox_->setButtonText("Use track name");
+    useTrackNameCheckbox_->setClickingTogglesState(false); // FrontendConnector controls state
     addAndMakeVisible(useTrackNameCheckbox_.get());
 
     routingLabel_->setFont(EarFonts::Label);

--- a/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
@@ -16,15 +16,19 @@ class ValueBoxMain : public Component {
   ValueBoxMain()
       : colourComboBox_(std::make_shared<EarComboBox>()),
         name_(std::make_shared<EarNameTextEditor>()),
+        useTrackNameCheckbox_(std::make_shared<ToggleButton>()),
         routingLabel_(std::make_unique<Label>()),
         routingComboBox_(std::make_shared<EarComboBox>()) {
     setColour(backgroundColourId, EarColours::Area04dp);
 
-    name_->setLabelText("Name");
+    name_->setLabelText("Object Name");
     name_->setText("Object_1");
     name_->setEnabled(false);
     name_->setAlpha(0.38f);
     addAndMakeVisible(name_.get());
+
+    useTrackNameCheckbox_->setButtonText("Use track name");
+    addAndMakeVisible(useTrackNameCheckbox_.get());
 
     routingLabel_->setFont(EarFonts::Label);
     routingLabel_->setText("Routing",
@@ -64,12 +68,12 @@ class ValueBoxMain : public Component {
 
     area.removeFromTop(marginBig_);
 
-    auto descArea = area.removeFromTop(63);
+    auto descArea = area.removeFromTop(90);
     auto colourArea = descArea.withWidth(labelWidth_);
-    colourComboBox_->setBounds(colourArea);
-    auto nameArea = descArea.withTrimmedLeft(labelWidth_ + marginBig_)
-                        .reduced(0, marginSmall_);
-    name_->setBounds(nameArea);
+    colourComboBox_->setBounds(colourArea.removeFromTop(63));
+    auto nameArea = descArea.withTrimmedLeft(labelWidth_ + marginBig_);
+    name_->setBounds(nameArea.removeFromTop(63).reduced(0, marginSmall_));
+    useTrackNameCheckbox_->setBounds(nameArea);
 
     area.removeFromTop(15.f);
 
@@ -83,6 +87,7 @@ class ValueBoxMain : public Component {
   }
 
   std::shared_ptr<EarNameTextEditor> getNameTextEditor() { return name_; }
+  std::shared_ptr<ToggleButton> getUseTrackNameCheckbox() { return useTrackNameCheckbox_; }
   std::shared_ptr<EarComboBox> getColourComboBox() { return colourComboBox_; }
   std::shared_ptr<EarComboBox> getRoutingComboBox() { return routingComboBox_; }
 
@@ -96,6 +101,7 @@ class ValueBoxMain : public Component {
   std::shared_ptr<EarNameTextEditor> name_;
   std::unique_ptr<Label> routingLabel_;
   std::shared_ptr<EarComboBox> routingComboBox_;
+  std::shared_ptr<ToggleButton> useTrackNameCheckbox_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ValueBoxMain)
 };

--- a/shared/components/ear_name_text_editor.hpp
+++ b/shared/components/ear_name_text_editor.hpp
@@ -19,6 +19,17 @@ class EarNameTextEditor : public TextEditor {
     setMultiLine(false);
     setJustification(Justification::topLeft);
     setBorder(BorderSize<int>(0, textIndent, 0, textIndent));
+    onReturnKey = [this]() {
+        this->lastAcceptedText = this->TextEditor::getText();
+        this->unfocusAllComponents();
+    };
+    onEscapeKey = [this]() {
+        this->setText(this->lastAcceptedText);
+        this->unfocusAllComponents();
+    };
+    onFocusLost = [this]() {
+        this->lastAcceptedText = this->TextEditor::getText();
+    };
   }
 
   void setLabelText(const String& l) {
@@ -35,6 +46,7 @@ class EarNameTextEditor : public TextEditor {
 
   void setText(const String& text, bool sendTextChangeMessage = true) {
     TextEditor::setText(text, sendTextChangeMessage);
+    lastAcceptedText = text;
     scrollToMakeSureCursorIsVisible();
   }
 
@@ -45,6 +57,7 @@ class EarNameTextEditor : public TextEditor {
   // --
 
   ear::plugin::ui::NameTextEditorLookAndFeel earNameTextEditorLookAndFeel_;
+  juce::String lastAcceptedText;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EarNameTextEditor)
 };


### PR DESCRIPTION
Checkbox implemented - will enable/disable editing of name editor
State held in frontend connector. Messaging to scene is working. Save/load of state is working.