### PR TITLE
Force use of RF64 ID on assets to be reimported

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = https://github.com/ebu/libadm.git
 [submodule "submodules/libbw64"]
 	path = submodules/libbw64
-	url = https://github.com/ebu/libbw64.git
+	url = https://github.com/firthm01/libbw64.git
+	branch = rf64-id-option-v2
 # Not required - BEAR will pull a version in
 # [submodule "submodules/libear"]
 # 	path = submodules/libear

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,7 @@
 	url = https://github.com/ebu/libadm.git
 [submodule "submodules/libbw64"]
 	path = submodules/libbw64
-	url = https://github.com/firthm01/libbw64.git
-	branch = rf64-id-option-v2
+	url = https://github.com/ebu/libbw64.git
 # Not required - BEAR will pull a version in
 # [submodule "submodules/libear"]
 # 	path = submodules/libear

--- a/reaper-adm-extension/src/reaper_adm/pcmwriter.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pcmwriter.cpp
@@ -15,6 +15,7 @@ void PCMWriter::write(const IPCMBlock &block)
 {
     if(!writer) {
         writer = bw64::writeFile(fileName().c_str(), block.channelCount(), block.sampleRate(), 24);
+        writer->useRf64Id(true); // REAPER currently doesn't recognise BW64 chunk ID when we pull on to track
     }
     auto framesWritten = writer->write(&block.data()[0], block.frameCount());
 }


### PR DESCRIPTION
Creating a project from an ADM BW64 which contains large assets (>4gb when extracted) would fail to reimport those assets due to REAPER not recognising the BW64 chunk ID. RF64 is supported and since we are not using the additional chunks of BW64 in this process, it is perfectly acceptable to use the RF64 ID.

Note that this fix involves using a custom fork of libbw64 in order to force use of RF64.