### PR TITLE
Fix conversion to 2076-1 on import

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/admmetadata.cpp
+++ b/reaper-adm-extension/src/reaper_adm/admmetadata.cpp
@@ -25,6 +25,7 @@ void setUidReference(adm::Document& doc,
     if(cf) {
         auto tf = adm::AudioTrackFormat::create(adm::AudioTrackFormatName("AudioTrackFormat"), adm::FormatDefinition::PCM);
         auto sf = adm::AudioStreamFormat::create(adm::AudioStreamFormatName("AudioStreamFormat"), adm::FormatDefinition::PCM);
+        uid.removeReference<adm::AudioChannelFormat>();
         uid.setReference(tf);
         tf->setReference(sf);
         sf->setReference(cf);


### PR DESCRIPTION
The conversion function must remove the existing ACF reference from the ATU before adding a AT ref, otherwise libadm throws.