### PR TITLE
Improve performance when creating Reaper automation points

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/automationenvelope.cpp
+++ b/reaper-adm-extension/src/reaper_adm/automationenvelope.cpp
@@ -34,14 +34,14 @@ void DefinedStartEnvelope::createPoints(double pointsOffset)
 {
     double earliestPointOnTimeline{ -1.0 };
     double pointOnTimeline{ 0.0 };
-    bool sortPoints{false};
+    bool noSortPoints{true};
 
     for(auto& point : points) {
         pointOnTimeline = point.effectiveTime() + pointsOffset;
         if (earliestPointOnTimeline < 0.0 || pointOnTimeline < earliestPointOnTimeline) {
             earliestPointOnTimeline = pointOnTimeline;
         }
-        api.InsertEnvelopePoint(trackEnvelope, pointOnTimeline, point.value(), 0, 0, false, &sortPoints);
+        api.InsertEnvelopePoint(trackEnvelope, pointOnTimeline, point.value(), 0, 0, false, &noSortPoints);
     }
     api.Envelope_SortPoints(trackEnvelope);
 


### PR DESCRIPTION
See: [Reaper API - InsertEnvelopePoint](https://www.reaper.fm/sdk/reascript/reascripthelp.html#InsertEnvelopePoint)

InsertEnvelopePoint()'s sort control flag works opposite to the way you'd expect.  Flipping this code around prevents Reaper from re-sorting the automation curve for each point added, which significantly reduces import time.