### PR TITLE
128 channel support

### DIFF
--- a/ear-production-suite-plugins/lib/src/store_metadata.cpp
+++ b/ear-production-suite-plugins/lib/src/store_metadata.cpp
@@ -391,7 +391,7 @@ void Metadata::setElementOrder(const ProgrammeInternalId &progId, const std::vec
 }
 
 // This is horribly inefficient algorithm wise (O(n^2)?).
-// OTOH, order.size() is always <= 64 so a linear vector search probably still wins over a map. (it may fit in cache.)
+// OTOH, order.size() is probably <= 128 (unless asset reuse and huge project) so a linear vector search probably still wins over a map. (it may fit in cache.)
 // If this ends up profiling slow, try changing it.
 // This should only be called rarely (on a routing change in auto mode or an element move in the GUI),
 // so it's not on a hot path.

--- a/ear-production-suite-plugins/plugins/binaural_monitoring/src/binaural_monitoring_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/binaural_monitoring/src/binaural_monitoring_plugin_processor.cpp
@@ -6,7 +6,7 @@
 #include "variable_block_adapter.hpp"
 #include <version/eps_version.h>
 #include <helper/resource_paths_juce-file.hpp>
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 #define DEFAULT_OSC_PORT 8000
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/channel_meter_layout.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/channel_meter_layout.hpp
@@ -60,6 +60,9 @@ class ChannelMeterLayout : public Component {
     if(speakerLevels_.size() > 18) meterRows = 4;
 
     auto metersBoxHeight = area.getHeight() / meterRows;
+    // 6 meters require 337 px - centre them with left padding
+    int leftPad = (area.getWidth() - 337) / 2;
+    if (leftPad > 0) area.removeFromLeft(leftPad);
 
     auto metersBoxArea = area.removeFromTop(metersBoxHeight);
     channelMeterBox1to6_->setBounds(metersBoxArea.reduced(0, 5));

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_component.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_component.hpp
@@ -2,6 +2,7 @@
 
 #include "JuceHeader.h"
 
+#include "components/look_and_feel/tooltips.hpp"
 #include "components/ear_combo_box.hpp"
 #include "components/onboarding.hpp"
 #include "components/overlay.hpp"
@@ -42,6 +43,10 @@ class DirectSpeakersComponent : public Component,
         propertiesFileLock(
             std::make_unique<InterProcessLock>("EPS_preferences")),
         propertiesFile(getPropertiesFile(propertiesFileLock.get())) {
+
+    tooltipWindow.setLookAndFeel(&tooltipLookAndFeel);
+    tooltipWindow.setOpaque(false);
+
     header->setText(" Direct Speakers");
 
     onBoardingButton->setButtonText("?");
@@ -68,6 +73,7 @@ class DirectSpeakersComponent : public Component,
     addChildComponent(onBoardingOverlay.get());
 
     //addAndMakeVisible(metadataValueBox.get());
+    mainValueBox->showRoutingTooltip(p->getNumDawChannels() < 128);
     addAndMakeVisible(mainValueBox.get());
     addAndMakeVisible(channelMetersBox.get());
 
@@ -110,8 +116,10 @@ class DirectSpeakersComponent : public Component,
         headingArea.removeFromRight(39).removeFromBottom(39));
     header->setBounds(headingArea);
 
-    auto leftColumn = area.withTrimmedRight(area.getWidth() / 2);
-    auto rightColumn = area.withTrimmedLeft(area.getWidth() / 2);
+    auto leftColumnWidth = area.getWidth() / 2;
+    if (leftColumnWidth < 385) leftColumnWidth = 385;
+    auto leftColumn = area.removeFromLeft(leftColumnWidth);
+    auto rightColumn = area;
 
     // left column
     mainValueBox->setBounds(leftColumn.removeFromTop(223).reduced(5, 5));
@@ -161,6 +169,10 @@ class DirectSpeakersComponent : public Component,
 
  private:
   DirectSpeakersAudioProcessor* p_;
+
+  TooltipWindow tooltipWindow{this};
+  TooltipLookAndFeel tooltipLookAndFeel;
+
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DirectSpeakersComponent)
 };
 

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -5,7 +5,7 @@
 #include "detail/weak_ptr_helpers.hpp"
 
 #include "speaker_setups.hpp"
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 namespace {
   String routingLayoutDescriptionAt(int position, int layoutSizeFixed) {

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -188,7 +188,8 @@ void DirectSpeakersJuceFrontendConnector::setSpeakerSetup(
     routingComboBoxLocked->clearEntries();
     auto layoutSizeFixed = layoutSize != 0 ? layoutSize - 1 : layoutSize;
     for (int i = 1; i + layoutSizeFixed <= MAX_DAW_CHANNELS; ++i) {
-      routingComboBoxLocked->addTextEntry(routingLayoutDescriptionAt(i, layoutSizeFixed));
+      auto entry = routingComboBoxLocked->addTextEntry(routingLayoutDescriptionAt(i, layoutSizeFixed), i);
+      entry->setSelectable(i + layoutSizeFixed <= p_->getNumDawChannels());
     }
     routingComboBoxLocked->selectEntry(cachedRouting_, sendNotification);
   }

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_frontend_connector.cpp
@@ -5,6 +5,7 @@
 #include "detail/weak_ptr_helpers.hpp"
 
 #include "speaker_setups.hpp"
+#include <global_config.h>
 
 namespace {
   String routingLayoutDescriptionAt(int position, int layoutSizeFixed) {
@@ -186,7 +187,7 @@ void DirectSpeakersJuceFrontendConnector::setSpeakerSetup(
         speakerSetupByIndex(cachedSpeakerSetupIndex_).speakers.size();
     routingComboBoxLocked->clearEntries();
     auto layoutSizeFixed = layoutSize != 0 ? layoutSize - 1 : layoutSize;
-    for (int i = 1; i + layoutSizeFixed <= 64; ++i) {
+    for (int i = 1; i + layoutSizeFixed <= MAX_DAW_CHANNELS; ++i) {
       routingComboBoxLocked->addTextEntry(routingLayoutDescriptionAt(i, layoutSizeFixed));
     }
     routingComboBoxLocked->selectEntry(cachedRouting_, sendNotification);

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
@@ -5,6 +5,8 @@
 #include "direct_speakers_plugin_editor.hpp"
 #include "direct_speakers_frontend_connector.hpp"
 
+#include <global_config.h>
+
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();
 
@@ -24,7 +26,7 @@ DirectSpeakersAudioProcessor::DirectSpeakersAudioProcessor()
   addParameter(routing_ =
     new ui::NonAutomatedParameter<AudioParameterInt>(
       "routing", "Routing",
-      -1, 63, -1));
+      -1, MAX_DAW_CHANNELS-1, -1));
   addParameter(packFormatIdValue_ =
     new ui::NonAutomatedParameter<AudioParameterInt>(
       "packFormatIdValue", "PackFormat ID Value",

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
@@ -5,8 +5,6 @@
 #include "direct_speakers_plugin_editor.hpp"
 #include "direct_speakers_frontend_connector.hpp"
 
-#include <daw_channel_count.h>
-
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();
 
@@ -212,6 +210,12 @@ void DirectSpeakersAudioProcessor::setIHostApplication(Steinberg::FUnknown * unk
       registerPluginLoad([this](std::string const& xmlState) {
         this->extensionSetState(xmlState);
       });
+    }
+
+    auto getAppVersionPtr = reaperHost->getReaperApi("GetAppVersion");
+    numDawChannels_ = MAX_DAW_CHANNELS;
+    if (getAppVersionPtr) {
+      numDawChannels_ = GetReaperChannelCount(getAppVersionPtr);
     }
   }
 }

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.cpp
@@ -5,7 +5,7 @@
 #include "direct_speakers_plugin_editor.hpp"
 #include "direct_speakers_frontend_connector.hpp"
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/direct_speakers_plugin_processor.hpp
@@ -6,6 +6,7 @@
 #include "components/level_meter_calculator.hpp"
 #include "reaper_vst3_interfaces.h"
 #include "components/read_only_audio_parameter_int.hpp"
+#include <daw_channel_count.h>
 
 #include <memory>
 
@@ -72,6 +73,8 @@ class DirectSpeakersAudioProcessor : public AudioProcessor, public VST3ClientExt
   void setIHostApplication(Steinberg::FUnknown *unknown) override;
   void extensionSetState(std::string const& xmlState);
 
+  int getNumDawChannels() { return numDawChannels_; }
+
  private:
   IReaperHostApplication* reaperHost{ nullptr };
   ear::plugin::communication::ConnectionId connectionId_;
@@ -87,6 +90,7 @@ class DirectSpeakersAudioProcessor : public AudioProcessor, public VST3ClientExt
   std::unique_ptr<ear::plugin::DirectSpeakersBackend> backend_;
 
   int samplerate_;
+  int numDawChannels_{MAX_DAW_CHANNELS};
   std::shared_ptr<ear::plugin::LevelMeterCalculator> levelMeter_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DirectSpeakersAudioProcessor)

--- a/ear-production-suite-plugins/plugins/direct_speakers/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/direct_speakers/src/value_box_main.hpp
@@ -20,6 +20,7 @@ class ValueBoxMain : public Component {
         speakerSetupLabel_(std::make_unique<Label>()),
         speakerSetupsComboBox_(std::make_shared<EarComboBox>()),
         routingLabel_(std::make_unique<Label>()),
+        routingInfoIcon_(std::make_unique<ImageComponent>()),
         routingComboBox_(std::make_shared<EarComboBox>()) {
     name_->setLabelText("Object Name");
     name_->setText("Object_1");
@@ -37,6 +38,16 @@ class ValueBoxMain : public Component {
     routingLabel_->setColour(Label::textColourId, EarColours::Label);
     routingLabel_->setJustificationType(Justification::right);
     addAndMakeVisible(routingLabel_.get());
+
+    routingInfoIcon_->setImage(ImageFileFormat::loadFrom(
+        binary_data::infologo_png, binary_data::infologo_pngSize));
+    routingInfoIcon_->setImagePlacement(RectanglePlacement::centred +
+                                        RectanglePlacement::doNotResize);
+    routingInfoIcon_->setAlpha(0.8);
+    routingInfoIcon_->setMouseCursor(MouseCursor::PointingHandCursor);
+    routingInfoIcon_->setTooltip(
+        "128 channel support requires REAPER v7 or later.");
+    addChildComponent(routingInfoIcon_.get());
 
     routingComboBox_->setDefaultText("Select Scene channel range");
     addAndMakeVisible(routingComboBox_.get());
@@ -92,11 +103,23 @@ class ValueBoxMain : public Component {
 
     auto routingArea = area.removeFromTop(rowHeight_);
     auto routingLabelArea = routingArea.withWidth(labelWidth_);
+    routingLabel_->setBounds(routingLabelArea);
+    if (routingInfoIcon_->isVisible()) {
+      auto routingInfoArea = routingArea.removeFromRight(13).withTrimmedTop(
+          1);  // Trimming 1 to get an odd height. Icon is odd height too, so
+               // ensures an integer number of pixels padding top and bottom to
+               // avoid blurring through anti-aliasing.
+      routingInfoIcon_->setBounds(routingInfoArea);
+      routingArea.removeFromRight(marginSmall_);
+    }
     auto routingComboBoxArea =
         routingArea.withTrimmedLeft(labelWidth_ + marginBig_)
             .reduced(0, marginSmall_);
-    routingLabel_->setBounds(routingLabelArea);
     routingComboBox_->setBounds(routingComboBoxArea);
+  }
+
+  void showRoutingTooltip(bool visible) {
+    routingInfoIcon_->setVisible(visible);
   }
 
   std::shared_ptr<EarNameTextEditor> getNameTextEditor() { return name_; }
@@ -119,6 +142,7 @@ class ValueBoxMain : public Component {
   std::shared_ptr<EarComboBox> speakerSetupsComboBox_;
   std::unique_ptr<Label> routingLabel_;
   std::shared_ptr<EarComboBox> routingComboBox_;
+  std::shared_ptr<ImageComponent> routingInfoIcon_;
   std::shared_ptr<ToggleButton> useTrackNameCheckbox_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ValueBoxMain)

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_component.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_component.hpp
@@ -2,6 +2,7 @@
 
 #include "JuceHeader.h"
 
+#include "components/look_and_feel/tooltips.hpp"
 #include "components/onboarding.hpp"
 #include "components/overlay.hpp"
 #include "helper/properties_file.hpp"
@@ -31,6 +32,9 @@ class HoaComponent : public Component,
         propertiesFileLock(
             std::make_unique<InterProcessLock>("EPS_preferences")),
         propertiesFile(getPropertiesFile(propertiesFileLock.get())) {
+
+    tooltipWindow.setLookAndFeel(&tooltipLookAndFeel);
+    tooltipWindow.setOpaque(false);
 
     header->setName("EarHeader (HoaComponent::header)");
     onBoardingButton->setName("EarButton (HoaComponent::onBoardingButton)");
@@ -65,6 +69,7 @@ class HoaComponent : public Component,
     addAndMakeVisible(onBoardingButton.get());
     addChildComponent(onBoardingOverlay.get());
 
+    mainValueBox->showRoutingTooltip(p->getNumDawChannels() < 128);
     addAndMakeVisible(mainValueBox.get());
     addAndMakeVisible(orderDisplayValueBox.get());
 
@@ -128,6 +133,10 @@ class HoaComponent : public Component,
 
  private:
   HoaAudioProcessor* p_;
+
+  TooltipWindow tooltipWindow{this};
+  TooltipLookAndFeel tooltipLookAndFeel;
+
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HoaComponent)
 };
 

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
@@ -4,6 +4,8 @@
 #include "components/ear_name_text_editor.hpp"
 #include "detail/weak_ptr_helpers.hpp"
 
+#include <global_config.h>
+
 namespace {
 String routingLayoutDescriptionAt(int position, int layoutSizeFixed) {
   return String(position) + String::fromUTF8("-") +
@@ -175,7 +177,7 @@ void HoaJuceFrontendConnector::setHoaType(int hoaType) {
 
     routingComboBoxLocked->clearEntries();
     auto cfCountFixed = cfCount != 0 ? cfCount - 1 : cfCount;
-    for (int i = 1; i + cfCountFixed <= 64; ++i) {
+    for (int i = 1; i + cfCountFixed <= MAX_DAW_CHANNELS; ++i) {
       routingComboBoxLocked->addTextEntry(
           routingLayoutDescriptionAt(i, cfCountFixed));
     }

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
@@ -178,8 +178,9 @@ void HoaJuceFrontendConnector::setHoaType(int hoaType) {
     routingComboBoxLocked->clearEntries();
     auto cfCountFixed = cfCount != 0 ? cfCount - 1 : cfCount;
     for (int i = 1; i + cfCountFixed <= MAX_DAW_CHANNELS; ++i) {
-      routingComboBoxLocked->addTextEntry(
-          routingLayoutDescriptionAt(i, cfCountFixed));
+      auto entry = routingComboBoxLocked->addTextEntry(
+          routingLayoutDescriptionAt(i, cfCountFixed), i);
+      entry->setSelectable(i + cfCountFixed <= p_->getNumDawChannels());
     }
     routingComboBoxLocked->selectEntry(cachedRouting_, sendNotification);
   }

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_frontend_connector.cpp
@@ -4,7 +4,7 @@
 #include "components/ear_name_text_editor.hpp"
 #include "detail/weak_ptr_helpers.hpp"
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 namespace {
 String routingLayoutDescriptionAt(int position, int layoutSizeFixed) {

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
@@ -5,8 +5,6 @@
 #include "hoa_frontend_connector.hpp"
 #include "components/level_meter_calculator.hpp"
 
-#include <daw_channel_count.h>
-
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();
 
@@ -199,6 +197,12 @@ void HoaAudioProcessor::setIHostApplication(Steinberg::FUnknown * unknown)
       registerPluginLoad([this](std::string const& xmlState) {
         this->extensionSetState(xmlState);
       });
+    }
+
+    auto getAppVersionPtr = reaperHost->getReaperApi("GetAppVersion");
+    numDawChannels_ = MAX_DAW_CHANNELS;
+    if (getAppVersionPtr) {
+      numDawChannels_ = GetReaperChannelCount(getAppVersionPtr);
     }
   }
 }

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
@@ -5,7 +5,7 @@
 #include "hoa_frontend_connector.hpp"
 #include "components/level_meter_calculator.hpp"
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.cpp
@@ -5,6 +5,8 @@
 #include "hoa_frontend_connector.hpp"
 #include "components/level_meter_calculator.hpp"
 
+#include <global_config.h>
+
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();
 
@@ -25,7 +27,7 @@ HoaAudioProcessor::HoaAudioProcessor()
   addParameter(routing_ =
     new ui::NonAutomatedParameter<AudioParameterInt>(
       "routing", "Routing",
-      -1, 63, -1));
+      -1, MAX_DAW_CHANNELS-1, -1));
   addParameter(packFormatIdValue_ =
     new ui::NonAutomatedParameter<AudioParameterInt>(
       "packformat_id_value", "PackFormat ID Value",

--- a/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/hoa_plugin_processor.hpp
@@ -6,6 +6,7 @@
 #include "helper/common_definition_helper.h"
 #include "reaper_vst3_interfaces.h"
 #include "components/read_only_audio_parameter_int.hpp"
+#include <daw_channel_count.h>
 
 namespace ear {
 namespace plugin {
@@ -72,6 +73,8 @@ class HoaAudioProcessor : public AudioProcessor, public VST3ClientExtensions {
   void setIHostApplication(Steinberg::FUnknown *unknown) override;
   void extensionSetState(std::string const& xmlState);
 
+  int getNumDawChannels() { return numDawChannels_; }
+
  private:
   IReaperHostApplication* reaperHost{ nullptr };
   ear::plugin::communication::ConnectionId connectionId_;
@@ -86,6 +89,7 @@ class HoaAudioProcessor : public AudioProcessor, public VST3ClientExtensions {
   std::unique_ptr<ear::plugin::HoaBackend> backend_;
 
   int samplerate_;
+  int numDawChannels_{MAX_DAW_CHANNELS};
   std::shared_ptr<ear::plugin::LevelMeterCalculator> levelMeterCalculator_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(HoaAudioProcessor)

--- a/ear-production-suite-plugins/plugins/hoa/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/hoa/src/value_box_main.hpp
@@ -19,6 +19,7 @@ class ValueBoxMain : public Component {
         hoaTypeLabel_(std::make_unique<Label>()),
         hoaTypeComboBox_(std::make_shared<EarComboBox>()),
         routingLabel_(std::make_unique<Label>()),
+        routingInfoIcon_(std::make_unique<ImageComponent>()),
         routingComboBox_(std::make_shared<EarComboBox>()) {
 
     colourComboBox_->setName("EarComboBox (ValueBoxMain::colourComboBox_)");
@@ -44,6 +45,16 @@ class ValueBoxMain : public Component {
     routingLabel_->setColour(Label::textColourId, EarColours::Label);
     routingLabel_->setJustificationType(Justification::right);
     addAndMakeVisible(routingLabel_.get());
+
+    routingInfoIcon_->setImage(ImageFileFormat::loadFrom(
+        binary_data::infologo_png, binary_data::infologo_pngSize));
+    routingInfoIcon_->setImagePlacement(RectanglePlacement::centred +
+                                        RectanglePlacement::doNotResize);
+    routingInfoIcon_->setAlpha(0.8);
+    routingInfoIcon_->setMouseCursor(MouseCursor::PointingHandCursor);
+    routingInfoIcon_->setTooltip(
+        "128 channel support requires REAPER v7 or later.");
+    addChildComponent(routingInfoIcon_.get());
 
     routingComboBox_->setDefaultText("Select Scene channel range");
     addAndMakeVisible(routingComboBox_.get());
@@ -108,11 +119,20 @@ class ValueBoxMain : public Component {
 
     auto routingArea = area.removeFromTop(rowHeight_);
     auto routingLabelArea = routingArea.withWidth(labelWidth_);
+    routingLabel_->setBounds(routingLabelArea);
+    if (routingInfoIcon_->isVisible()) {
+      auto routingInfoArea = routingArea.removeFromRight(13).withTrimmedTop(1);  // Trimming 1 to get an odd height. Icon is odd height too, so ensures an integer number of pixels padding top and bottom to avoid blurring through anti-aliasing.
+      routingInfoIcon_->setBounds(routingInfoArea);
+      routingArea.removeFromRight(marginSmall_);
+    }
     auto routingComboBoxArea =
         routingArea.withTrimmedLeft(labelWidth_ + marginBig_)
             .reduced(0, marginSmall_);
-    routingLabel_->setBounds(routingLabelArea);
     routingComboBox_->setBounds(routingComboBoxArea);
+  }
+
+  void showRoutingTooltip(bool visible) {
+    routingInfoIcon_->setVisible(visible);
   }
 
   std::shared_ptr<EarNameTextEditor> getNameTextEditor() { return name_; }
@@ -136,6 +156,7 @@ class ValueBoxMain : public Component {
 
   std::unique_ptr<Label> routingLabel_;
   std::shared_ptr<EarComboBox> routingComboBox_;
+  std::shared_ptr<ImageComponent> routingInfoIcon_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ValueBoxMain)
 };

--- a/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
@@ -2,7 +2,7 @@
 #include "monitoring_plugin_editor.hpp"
 #include "variable_block_adapter.hpp"
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 namespace ear {
 namespace plugin {

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_editor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_editor.cpp
@@ -47,6 +47,8 @@ ObjectAudioProcessorEditor::ObjectAudioProcessorEditor(ObjectsAudioProcessor* p)
   p->getFrontendConnector()->setPannerSideView(content_->panningViewValueBox->getPannerSideView());
   /* clang-format on */
 
+  content_->mainValueBox->setValidRoutingMax(p->getNumDawChannels());
+
   viewport_->setViewedComponent(content_.get(), false);
   viewport_->setScrollBarsShown(true, true);
   viewport_->getHorizontalScrollBar().setColour(ScrollBar::thumbColourId,

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
@@ -5,7 +5,7 @@
 #include "object_frontend_connector.hpp"
 #include "object_plugin_editor.hpp"
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
@@ -5,8 +5,6 @@
 #include "object_frontend_connector.hpp"
 #include "object_plugin_editor.hpp"
 
-#include <daw_channel_count.h>
-
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();
 
@@ -269,6 +267,12 @@ void ObjectsAudioProcessor::setIHostApplication(Steinberg::FUnknown * unknown)
       registerPluginLoad([this](std::string const& xmlState) {
         this->extensionSetState(xmlState);
       });
+    }
+
+    auto getAppVersionPtr = reaperHost->getReaperApi("GetAppVersion");
+    numDawChannels_ = MAX_DAW_CHANNELS;
+    if (getAppVersionPtr) {
+      numDawChannels_ = GetReaperChannelCount(getAppVersionPtr);
     }
   }
 }

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.cpp
@@ -5,6 +5,8 @@
 #include "object_frontend_connector.hpp"
 #include "object_plugin_editor.hpp"
 
+#include <global_config.h>
+
 void registerPluginLoadSig(std::function<void(std::string const&)>);
 uint32_t requestInputInstanceIdSig();
 
@@ -28,7 +30,7 @@ ObjectsAudioProcessor::ObjectsAudioProcessor()
       samplerate_(48000),
       levelMeter_(std::make_shared<LevelMeterCalculator>(1, samplerate_)) {
   /* clang-format off */
-  addParameter(routing_ = new ui::NonAutomatedParameter<AudioParameterInt>("routing", "Routing", -1, 63, -1));
+  addParameter(routing_ = new ui::NonAutomatedParameter<AudioParameterInt>("routing", "Routing", -1, MAX_DAW_CHANNELS-1, -1));
   addParameter(gain_ = new AudioParameterFloat("gain", "Gain", NormalisableRange<float>{-100.f, 6.f}, 0.f));
   addParameter(azimuth_ = new AudioParameterFloat("azimuth", "Azimuth", NormalisableRange<float>{-180.f, 180.f}, 0.f));
   addParameter(elevation_ = new AudioParameterFloat("elevation", "Elevation", NormalisableRange<float>{-90.f, 90.f}, 0.f));

--- a/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/object_plugin_processor.hpp
@@ -7,6 +7,7 @@
 #include "communication/common_types.hpp"
 #include "reaper_vst3_interfaces.h"
 #include "components/read_only_audio_parameter_int.hpp"
+#include <daw_channel_count.h>
 
 namespace ear {
 namespace plugin {
@@ -83,6 +84,8 @@ class ObjectsAudioProcessor : public AudioProcessor, public VST3ClientExtensions
   void setIHostApplication(Steinberg::FUnknown *unknown) override;
   void extensionSetState(std::string const& xmlState);
 
+  int getNumDawChannels() { return numDawChannels_; }
+
  private:
   IReaperHostApplication* reaperHost{ nullptr };
   ear::plugin::communication::ConnectionId connectionId_;
@@ -110,6 +113,7 @@ class ObjectsAudioProcessor : public AudioProcessor, public VST3ClientExtensions
 
   int samplerate_;
   int numPluginChannels_;
+  int numDawChannels_{MAX_DAW_CHANNELS};
   std::shared_ptr<ear::plugin::LevelMeterCalculator> levelMeter_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ObjectsAudioProcessor)

--- a/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
@@ -6,7 +6,7 @@
 #include "components/ear_name_text_editor.hpp"
 #include "components/look_and_feel/colours.hpp"
 #include "components/look_and_feel/fonts.hpp"
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 namespace ear {
 namespace plugin {

--- a/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
@@ -6,6 +6,7 @@
 #include "components/ear_name_text_editor.hpp"
 #include "components/look_and_feel/colours.hpp"
 #include "components/look_and_feel/fonts.hpp"
+#include <global_config.h>
 
 namespace ear {
 namespace plugin {
@@ -39,7 +40,7 @@ class ValueBoxMain : public Component {
     addAndMakeVisible(routingLabel_.get());
     // routingComboBox_->setLookAndFeel(&routingLookAndFeel_);
     routingComboBox_->setDefaultText("Select Scene channel");
-    for (int i = 1; i <= 64; ++i) {
+    for (int i = 1; i <= MAX_DAW_CHANNELS; ++i) {
       routingComboBox_->addTextEntry(String(i));
     }
     addAndMakeVisible(routingComboBox_.get());

--- a/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
@@ -41,7 +41,7 @@ class ValueBoxMain : public Component {
     // routingComboBox_->setLookAndFeel(&routingLookAndFeel_);
     routingComboBox_->setDefaultText("Select Scene channel");
     for (int i = 1; i <= MAX_DAW_CHANNELS; ++i) {
-      routingComboBox_->addTextEntry(String(i));
+      routingComboBox_->addTextEntry(String(i), i);
     }
     addAndMakeVisible(routingComboBox_.get());
 
@@ -92,6 +92,17 @@ class ValueBoxMain : public Component {
   std::shared_ptr<ToggleButton> getUseTrackNameCheckbox() { return useTrackNameCheckbox_; }
   std::shared_ptr<EarComboBox> getColourComboBox() { return colourComboBox_; }
   std::shared_ptr<EarComboBox> getRoutingComboBox() { return routingComboBox_; }
+
+  void setValidRoutingMax(int maxChVal) { 
+    if (auto popup = routingComboBox_->getPopup()) {
+      for (int i = 1; i <= MAX_DAW_CHANNELS; ++i) {
+        auto entry = popup->getEntryById(i);
+        if (entry) {
+          entry->setSelectable(i <= maxChVal);
+        }
+      }
+    }
+  }
 
  private:
   const float labelWidth_ = 110.f;

--- a/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
+++ b/ear-production-suite-plugins/plugins/object/src/value_box_main.hpp
@@ -19,6 +19,7 @@ class ValueBoxMain : public Component {
         name_(std::make_shared<EarNameTextEditor>()),
         useTrackNameCheckbox_(std::make_shared<ToggleButton>()),
         routingLabel_(std::make_unique<Label>()),
+        routingInfoIcon_(std::make_unique<ImageComponent>()),
         routingComboBox_(std::make_shared<EarComboBox>()) {
     setColour(backgroundColourId, EarColours::Area04dp);
 
@@ -31,6 +32,15 @@ class ValueBoxMain : public Component {
     useTrackNameCheckbox_->setButtonText("Use track name");
     useTrackNameCheckbox_->setClickingTogglesState(false); // FrontendConnector controls state
     addAndMakeVisible(useTrackNameCheckbox_.get());
+
+    routingInfoIcon_->setImage(ImageFileFormat::loadFrom(
+        binary_data::infologo_png, binary_data::infologo_pngSize));
+    routingInfoIcon_->setImagePlacement(RectanglePlacement::centred +
+                                      RectanglePlacement::doNotResize);
+    routingInfoIcon_->setAlpha(0.8);
+    routingInfoIcon_->setMouseCursor(MouseCursor::PointingHandCursor);
+    routingInfoIcon_->setTooltip("128 channel support requires REAPER v7 or later.");
+    addChildComponent(routingInfoIcon_.get());
 
     routingLabel_->setFont(EarFontsSingleton::instance().Label);
     routingLabel_->setText("Routing",
@@ -81,10 +91,15 @@ class ValueBoxMain : public Component {
 
     auto routingArea = area.removeFromTop(rowHeight_);
     auto routingLabelArea = routingArea.withWidth(labelWidth_);
+    routingLabel_->setBounds(routingLabelArea);
+    if (routingInfoIcon_->isVisible()) {
+      auto routingInfoArea = routingArea.removeFromRight(13).withTrimmedTop(1); // Trimming 1 to get an odd height. Icon is odd height too, so ensures an integer number of pixels padding top and bottom to avoid blurring through anti-aliasing. 
+      routingInfoIcon_->setBounds(routingInfoArea);
+      routingArea.removeFromRight(marginSmall_);
+    }
     auto routingComboBoxArea =
         routingArea.withTrimmedLeft(labelWidth_ + marginBig_)
             .reduced(0, marginSmall_);
-    routingLabel_->setBounds(routingLabelArea);
     routingComboBox_->setBounds(routingComboBoxArea);
   }
 
@@ -93,7 +108,8 @@ class ValueBoxMain : public Component {
   std::shared_ptr<EarComboBox> getColourComboBox() { return colourComboBox_; }
   std::shared_ptr<EarComboBox> getRoutingComboBox() { return routingComboBox_; }
 
-  void setValidRoutingMax(int maxChVal) { 
+  void setValidRoutingMax(int maxChVal) {
+    routingInfoIcon_->setVisible(maxChVal < 128);
     if (auto popup = routingComboBox_->getPopup()) {
       for (int i = 1; i <= MAX_DAW_CHANNELS; ++i) {
         auto entry = popup->getEntryById(i);
@@ -115,6 +131,7 @@ class ValueBoxMain : public Component {
   std::unique_ptr<Label> routingLabel_;
   std::shared_ptr<EarComboBox> routingComboBox_;
   std::shared_ptr<ToggleButton> useTrackNameCheckbox_;
+  std::shared_ptr<ImageComponent> routingInfoIcon_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ValueBoxMain)
 };

--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
@@ -8,7 +8,7 @@
 #include "metadata_event_dispatcher.hpp"
 #include "pending_store.hpp"
 #include "restored_pending_store.hpp"
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 SceneAudioProcessor::SceneAudioProcessor()
     : AudioProcessor(

--- a/ear-production-suite-plugins/test/scene_gains_calculator_tests.cpp
+++ b/ear-production-suite-plugins/test/scene_gains_calculator_tests.cpp
@@ -4,10 +4,11 @@
 #include "eigen_catch2.hpp"
 #include <ear/bs2051.hpp>
 #include <catch2/catch_all.hpp>
+#include <global_config.h>
 
 using namespace ear::plugin;
 
-const int INPUT_CHANNELS = 64;
+const int INPUT_CHANNELS = MAX_DAW_CHANNELS;
 
 void updateExpectedGainMatrix(const ear::ObjectsTypeMetadata& metadata,
                               int track, ear::GainCalculatorObjects& calculator,

--- a/ear-production-suite-plugins/test/scene_gains_calculator_tests.cpp
+++ b/ear-production-suite-plugins/test/scene_gains_calculator_tests.cpp
@@ -4,7 +4,7 @@
 #include "eigen_catch2.hpp"
 #include <ear/bs2051.hpp>
 #include <catch2/catch_all.hpp>
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 using namespace ear::plugin;
 

--- a/ear-production-suite-plugins/test/scene_gains_calculator_tests.cpp
+++ b/ear-production-suite-plugins/test/scene_gains_calculator_tests.cpp
@@ -318,7 +318,7 @@ TEST_CASE("scene gain calculation (DirectSpeakers)") {
   SECTION("out of bounds routing") {
     auto item1 = store.add_monitoring_items();
     item1->set_connection_id(communication::ConnectionId::generate().string());
-    item1->set_routing(62);
+    item1->set_routing(INPUT_CHANNELS - 3); // item requires 10 channels but we're starting at only 3 channels away from the end of the available range
     item1->set_changed(true);
     item1->set_allocated_ds_metadata(obj1);
 

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
@@ -1,12 +1,13 @@
 #include "PluginEditor.h"
 #include "PluginProcessor.h"
 #include <fstream>
+#include <global_config.h>
 
 AdmStemPluginAudioProcessor::AdmStemPluginAudioProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations
   : AudioProcessor (BusesProperties()
-         .withInput("Input", AudioChannelSet::discreteChannels(64), true)
-         .withOutput("Output", AudioChannelSet::discreteChannels(64), true)
+         .withInput("Input", AudioChannelSet::discreteChannels(MAX_DAW_CHANNELS), true)
+         .withOutput("Output", AudioChannelSet::discreteChannels(MAX_DAW_CHANNELS), true)
      )
 #endif
 {
@@ -42,7 +43,7 @@ AdmStemPluginAudioProcessor::AdmStemPluginAudioProcessor()
 
     addParameter(numChnsParam = new ReadOnlyAudioParameterInt("numChns", // parameter ID
                                                               "Number of Channels defined by ADM essence type", // parameter name
-                                                              0, 64, 0)); // range and default value
+                                                              0, MAX_DAW_CHANNELS, 0)); // range and default value
 
     addParameter(admTypeDefinitionParam = new NonAutoAudioParameterInt("admTypeDefinition", // parameter ID
                                                                        "ADM essence type (typeDefinition)", // parameter name
@@ -382,8 +383,8 @@ void AdmStemPluginAudioProcessor::processBlock (AudioBuffer<float>& buffer, Midi
 #ifndef JucePlugin_PreferredChannelConfigurations
 bool AdmStemPluginAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
-    if (layouts.getMainOutputChannelSet() == AudioChannelSet::discreteChannels(64) &&
-        layouts.getMainInputChannelSet() == AudioChannelSet::discreteChannels(64)) {
+    if (layouts.getMainOutputChannelSet() == AudioChannelSet::discreteChannels(MAX_DAW_CHANNELS) &&
+        layouts.getMainInputChannelSet() == AudioChannelSet::discreteChannels(MAX_DAW_CHANNELS)) {
         return true;
     }
     return false;

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
@@ -1,7 +1,7 @@
 #include "PluginEditor.h"
 #include "PluginProcessor.h"
 #include <fstream>
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 AdmStemPluginAudioProcessor::AdmStemPluginAudioProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations

--- a/reaper-adm-export-source-plugin/src/customised_ear_combo_box.hpp
+++ b/reaper-adm-export-source-plugin/src/customised_ear_combo_box.hpp
@@ -125,7 +125,7 @@ class EarComboBoxPopup : public Component {
     return -1;
   }
 
-  int getEntryById(int id) {
+  int getEntryIndexById(int id) {
     for (int i = 0; i < entries_.size(); ++i) {
       if (entries_.at(i)->getId() == id) {
         return i;
@@ -302,7 +302,7 @@ class EarComboBox : public Component,
   bool hasSelection() { return getSelectedEntryIndex() >= 0; }
 
   bool setSelectedId(int id, NotificationType notification) {
-    auto index = popup_->getEntryById(id);
+    auto index = popup_->getEntryIndexById(id);
     if(index < 0) return false;
     selectEntry(index, notification);
     return true;

--- a/reaper-adm-extension/src/reaper_adm/CMakeLists.txt
+++ b/reaper-adm-extension/src/reaper_adm/CMakeLists.txt
@@ -77,12 +77,13 @@ set(EXTENSION_SOURCES
 	
 set(EXTENSION_HEADERS
 	${EPS_SHARED_DIR}/helper/common_definition_helper.h
-    ${EPS_SHARED_DIR}/helper/nng_wrappers.h
-    ${EPS_SHARED_DIR}/helper/char_encoding.hpp
-    ${EPS_SHARED_DIR}/helper/version.hpp
-    ${EPS_SHARED_DIR}/helper/resource_paths_juce-file.hpp
-    ${EPS_SHARED_DIR}/helper/resource_paths.hpp
-    ${EPS_SHARED_DIR}/helper/native_message_box.hpp
+	${EPS_SHARED_DIR}/helper/nng_wrappers.h
+	${EPS_SHARED_DIR}/helper/char_encoding.hpp
+	${EPS_SHARED_DIR}/helper/version.hpp
+	${EPS_SHARED_DIR}/helper/resource_paths_juce-file.hpp
+	${EPS_SHARED_DIR}/helper/resource_paths.hpp
+	${EPS_SHARED_DIR}/helper/native_message_box.hpp
+	${EPS_SHARED_DIR}/daw_channel_count.h
 	
 	AppConfig.h
 	juce_modules.h

--- a/reaper-adm-extension/src/reaper_adm/admvstcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/admvstcontrol.h
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <iomanip>
 
+#include <global_config.h>
+
 #define COMMONDEFINITIONS_MAX_ID 0x0FFF
 
 using namespace admplug;
@@ -26,7 +28,7 @@ using namespace admplug;
 #define ADM_VST_SAMPLERATEPARAM_NORMLIMIT 192000.0
 
 #define ADM_VST_NUMCHNSPARAM 4
-#define ADM_VST_NUMCHNSPARAM_NORMLIMIT 64.0
+#define ADM_VST_NUMCHNSPARAM_NORMLIMIT float(MAX_DAW_CHANNELS)
 
 #define ADM_VST_ADMTYPEDEFINITIONPARAM 5
 #define ADM_VST_ADMPACKFORMATPARAM 6

--- a/reaper-adm-extension/src/reaper_adm/admvstcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/admvstcontrol.h
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <iomanip>
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 #define COMMONDEFINITIONS_MAX_ID 0x0FFF
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <sstream>
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 using namespace admplug;
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.cpp
@@ -12,6 +12,8 @@
 #include <algorithm>
 #include <sstream>
 
+#include <global_config.h>
+
 using namespace admplug;
 
 EarVstExportSources::EarVstExportSources(ReaperAPI const & api) : IExportSources(api)
@@ -713,7 +715,7 @@ bool EarVstCommunicator::copyNextFrame(float * buf, bool bypassAvailabilityCheck
     }
 
     // Advance to the end of this data
-    int advanceAmount = 64 - currentReadPosChannelNumber;
+    int advanceAmount = MAX_DAW_CHANNELS - currentReadPosChannelNumber;
     // Sanity check; Make sure we haven't already exceeded the end of the message
     assert(advanceAmount >= 0);
     if(advanceAmount > 0) {
@@ -751,13 +753,13 @@ void EarVstCommunicator::admAndMappingExchange()
     // channelMappings must be sorted by originalChannel (which, in turn should be sorted for writtenChannelNumber too)
     // This makes it faster for the copyNextFrame method to jump between channels
 
-    std::vector<std::vector<PluginToAdmMap>>routingToPluginToAdmMaps(64);
+    std::vector<std::vector<PluginToAdmMap>>routingToPluginToAdmMaps(MAX_DAW_CHANNELS);
 
     for(auto const& pluginToAdmMap : pluginToAdmMaps) {
         if(pluginToAdmMap.audioObjectIdVal != 0x0000 &&
            pluginToAdmMap.audioTrackUidVal != 0x00000000 &&
            pluginToAdmMap.routing >= 0 &&
-           pluginToAdmMap.routing < 64) {
+           pluginToAdmMap.routing < MAX_DAW_CHANNELS) {
             routingToPluginToAdmMaps[pluginToAdmMap.routing].push_back(pluginToAdmMap);
         }
     }

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
@@ -8,6 +8,8 @@
 #include "exportaction_parameterprocessing.h"
 #include "helper/nng_wrappers.h"
 
+#include <global_config.h>
+
 #include <vector>
 #include <memory>
 
@@ -82,7 +84,7 @@ public:
 
 private:
 	// TODO: Fix hard-coded values - pull from plugin suite
-    std::unique_ptr<PluginParameter> paramTrackMapping{ createPluginParameter(0, { -1.0, 63.0 }) };
+    std::unique_ptr<PluginParameter> paramTrackMapping{ createPluginParameter(0, { -1.0, (float)(MAX_DAW_CHANNELS-1) }) };
     std::unique_ptr<PluginParameter> paramDirectSpeakersPackFormatIdValue{ createPluginParameter(1, { 0x0, 0xFFFF }) };
     std::unique_ptr<PluginParameter> paramHoaPackFormatIdValue{ createPluginParameter(1, { 0x0, 0xFFFF }) };
     std::unique_ptr<PluginParameter> paramObjectInstanceId{ createPluginParameter(16, { 0x0, 0xFFFF }) };

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsource-earvst.h
@@ -8,7 +8,7 @@
 #include "exportaction_parameterprocessing.h"
 #include "helper/nng_wrappers.h"
 
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 #include <vector>
 #include <memory>

--- a/reaper-adm-extension/src/reaper_adm/importaction.cpp
+++ b/reaper-adm-extension/src/reaper_adm/importaction.cpp
@@ -93,8 +93,28 @@ bool admplug::ImportAction::canMediaExplode_QuickCheck(const ReaperAPI & api, st
 {
     try {
         auto bw64File = bw64::readFile(mediaFile);
-        if (!bw64File->chnaChunk()) return false;
-        if (!bw64File->axmlChunk()) return false;
+        bool chnaMissing{ false };
+        bool axmlMissing{ false };
+        if (!bw64File->chnaChunk()) chnaMissing = true;
+        if (!bw64File->axmlChunk()) axmlMissing = true;
+        if (chnaMissing && axmlMissing) {
+            if (errOut) {
+                *errOut = "No CHNA or AXML chunk found.";
+            }
+            return false;
+        }
+        if (chnaMissing) {
+            if (errOut) {
+                *errOut = "No CHNA chunk found.";
+            }
+            return false;
+        }
+        if (axmlMissing) {
+            if (errOut) {
+                *errOut = "No AXML chunk found.";
+            }
+            return false;
+        }
     }
     catch (const std::runtime_error& e) {
         // Probably not RIFF/BW64/RF64 or not WAVE.

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
@@ -21,8 +21,7 @@
 #include <speaker_setups.hpp>
 #include <helper/common_definition_helper.h>
 #include <helper/container_helpers.hpp>
-
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 using namespace admplug;
 

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
@@ -286,7 +286,7 @@ void EARPluginSuite::onCreateProject(const ProjectNode&, const ReaperAPI & api)
 	trackMappingAssignerSearches.push_back(UniqueValueAssigner::SearchCandidate{ OBJECT_METADATA_PLUGIN_NAME, determineUsedObjectTrackMappingValues });
 	trackMappingAssignerSearches.push_back(UniqueValueAssigner::SearchCandidate{ DIRECTSPEAKERS_METADATA_PLUGIN_NAME, determineUsedDirectSpeakersTrackMappingValues });
 	trackMappingAssignerSearches.push_back(UniqueValueAssigner::SearchCandidate{ HOA_METADATA_PLUGIN_NAME, determineUsedHoaTrackMappingValues });
-	trackMappingAssigner = std::make_unique<UniqueValueAssigner>(trackMappingAssignerSearches, 0, TRACK_MAPPING_MAX, api);
+	trackMappingAssigner = std::make_unique<UniqueValueAssigner>(trackMappingAssignerSearches, 0, api.GetDawChannelCount() - 1, api);
 	checkForExistingTracks(api);
 	setTrackInsertionIndexFromSelectedMedia(api);
 	if (!Track::trackPresent(sceneMasterTrack.get())) {

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
@@ -22,10 +22,12 @@
 #include <helper/common_definition_helper.h>
 #include <helper/container_helpers.hpp>
 
+#include <global_config.h>
+
 using namespace admplug;
 
 #define TRACK_MAPPING_MIN -1
-#define TRACK_MAPPING_MAX 63
+#define TRACK_MAPPING_MAX MAX_DAW_CHANNELS - 1
 #define PACKFORMAT_ID_VALUE_MIN 0x0
 #define PACKFORMAT_ID_VALUE_MAX 0xFFFF
 
@@ -239,7 +241,7 @@ const char* EARPluginSuite::DIRECTSPEAKERS_METADATA_PLUGIN_NAME = "EAR DirectSpe
 const char* EARPluginSuite::HOA_METADATA_PLUGIN_NAME = "EAR HOA";
 const char* EARPluginSuite::SCENEMASTER_PLUGIN_NAME = "EAR Scene";
 const char* EARPluginSuite::RENDERER_PLUGIN_NAME = "EAR Monitoring 0+2+0";
-const int EARPluginSuite::MAX_CHANNEL_COUNT = 64;
+const int EARPluginSuite::MAX_CHANNEL_COUNT = MAX_DAW_CHANNELS;
 
 bool EARPluginSuite::registered = PluginRegistry::getInstance()->registerSupportedPluginSuite("EAR", std::make_shared<EARPluginSuite>());
 

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.cpp
@@ -240,7 +240,6 @@ const char* EARPluginSuite::DIRECTSPEAKERS_METADATA_PLUGIN_NAME = "EAR DirectSpe
 const char* EARPluginSuite::HOA_METADATA_PLUGIN_NAME = "EAR HOA";
 const char* EARPluginSuite::SCENEMASTER_PLUGIN_NAME = "EAR Scene";
 const char* EARPluginSuite::RENDERER_PLUGIN_NAME = "EAR Monitoring 0+2+0";
-const int EARPluginSuite::MAX_CHANNEL_COUNT = MAX_DAW_CHANNELS;
 
 bool EARPluginSuite::registered = PluginRegistry::getInstance()->registerSupportedPluginSuite("EAR", std::make_shared<EARPluginSuite>());
 
@@ -296,7 +295,7 @@ void EARPluginSuite::onCreateProject(const ProjectNode&, const ReaperAPI & api)
 		sceneMasterTrack->disableMasterSend();
 		if (!Track::trackPresent(rendererTrack.get())) {
 			rendererTrack = createBusTrack(RENDERER_PLUGIN_NAME, api);
-			sceneMasterTrack->routeTo(*rendererTrack, MAX_CHANNEL_COUNT);
+			sceneMasterTrack->routeTo(*rendererTrack, api.GetDawChannelCount());
 			rendererTrack->setName("EAR Monitor Bus");
 		}
 	}
@@ -311,7 +310,7 @@ std::unique_ptr<Track> EARPluginSuite::createBusTrack(std::string pluginName, Re
 	track->moveToBefore(trackInsertionIndex++);
 	track->hideFromTrackControlPanel();
 	track->createPlugin(pluginName);
-	track->setChannelCount(MAX_CHANNEL_COUNT);
+	track->setChannelCount(api.GetDawChannelCount());
 	return track;
 }
 

--- a/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.h
+++ b/reaper-adm-extension/src/reaper_adm/pluginsuite_ear.h
@@ -113,8 +113,6 @@ private:
 	std::string originalAdmDocument;
 	bool sceneMasterAlreadyExisted{ false };
 
-	static const int MAX_CHANNEL_COUNT;
-
 	static bool registered;
 };
 }

--- a/reaper-adm-extension/src/reaper_adm/reaperapi.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperapi.h
@@ -197,6 +197,7 @@ class ReaperAPI {
     virtual std::vector<std::pair<int, std::string>> GetVSTElementsFromTrackStateChunk(const std::string& fullChunk) const = 0;
     virtual std::vector<std::string> SplitVSTElement(const std::string& elm, bool stripBoundingQuotes, bool includeSeperators) const = 0;
     virtual std::string GetTrackStateChunkStr(MediaTrack* track) const = 0;
+    virtual int GetDawChannelCount() const = 0;
 
 };
 }

--- a/reaper-adm-extension/src/reaper_adm/reaperapi.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperapi.h
@@ -145,7 +145,6 @@ class ReaperAPI {
     virtual bool GetEnvelopeStateChunk(TrackEnvelope* env, char* strNeedBig, int strNeedBig_sz, bool isundoOptional) const = 0;
     virtual bool SetEnvelopeStateChunk(TrackEnvelope* env, const char* str, bool isundoOptional ) const = 0;
     virtual void* GetSetTrackSendInfo(MediaTrack* tr, int category, int sendidx, const char* parmname, void* setNewValue) const = 0;
-    virtual bool TrackFX_SetPinMappings(MediaTrack* tr, int fx, int isoutput, int pin, int low32bits, int hi32bits) const = 0;
     virtual int GetEnvelopeScalingMode(TrackEnvelope* env ) const = 0;
     virtual double ScaleFromEnvelopeMode(int scaling_mode, double val ) const = 0;
     virtual double ScaleToEnvelopeMode(int scaling_mode, double val ) const = 0;
@@ -188,8 +187,6 @@ class ReaperAPI {
     virtual std::unique_ptr<Track> createTrack(MediaTrack* track) const = 0;
     virtual std::unique_ptr<Track> masterTrack() const = 0;
     virtual ReaProject* getCurrentProject() const = 0;
-    virtual void resetFxPinMap(MediaTrack* trk, int fxNum) const = 0;
-    virtual void mapFxPin(MediaTrack* trk, int fxNum, int trackChannel, int fxChannel) const = 0;
     virtual bool forceAmplitudeScaling(TrackEnvelope * trackEnvelope) const = 0;
     virtual std::optional<std::pair<double, double>> getTrackAudioBounds(MediaTrack* trk, bool ignoreBeforeZero) const = 0;
     virtual bool TrackFX_GetActualFXName(MediaTrack* track, int fx, std::string& name) const = 0;

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
@@ -12,8 +12,7 @@
 #include "reaper_plugin_functions.h"
 #include "track.h"
 #include "plugin.h"
-
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 #define TWO_TO_THE_POWER_OF(power) (1<<power)
 

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
@@ -13,6 +13,8 @@
 #include "track.h"
 #include "plugin.h"
 
+#include <global_config.h>
+
 #define TWO_TO_THE_POWER_OF(power) (1<<power)
 
 extern void (*InsertTrackAtIndex)(int index, bool wantDefaults);
@@ -564,7 +566,7 @@ int ReaperAPIImpl::reaperChannelOffsetForBusWidth(int busWidth) const {
     case 1:     return 1024;
     case 2:     return 0;
     default:    {
-        if(busWidth > 64) {
+        if(busWidth > MAX_DAW_CHANNELS) {
             throw std::runtime_error("ReaperAPI::reaperChannelOffsetForBusWidth() bus width too large");
         }
         if(busWidth % 2) {
@@ -760,7 +762,7 @@ ReaProject* ReaperAPIImpl::getCurrentProject() const
 
 void admplug::ReaperAPIImpl::resetFxPinMap(MediaTrack * trk, int fxNum) const
 {
-    for(int pinNum = 0; pinNum < 64; pinNum++) {
+    for(int pinNum = 0; pinNum < MAX_DAW_CHANNELS; pinNum++) {
         mapFxPin(trk, fxNum, pinNum, pinNum);
     }
 }
@@ -771,7 +773,7 @@ void admplug::ReaperAPIImpl::mapFxPin(MediaTrack * trk, int fxNum, int trackChan
         uint32_t low = TWO_TO_THE_POWER_OF(trackChannel);
         TrackFX_SetPinMappings(trk, fxNum, 0, fxChannel, low, 0);
         TrackFX_SetPinMappings(trk, fxNum, 1, fxChannel, low, 0);
-    } else if(trackChannel < 64) {
+    } else if(trackChannel < 64) { // TODO - what about channels up to 128??
         trackChannel -= 32;
         uint32_t high = TWO_TO_THE_POWER_OF(trackChannel);
         TrackFX_SetPinMappings(trk, fxNum, 0, fxChannel, 0, high);

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
@@ -561,7 +561,7 @@ int ReaperAPIImpl::reaperChannelOffsetForBusWidth(int busWidth) const {
     case 1:     return 1024;
     case 2:     return 0;
     default:    {
-        if(busWidth > MAX_DAW_CHANNELS) {
+        if(busWidth > GetDawChannelCount()) {
             throw std::runtime_error("ReaperAPI::reaperChannelOffsetForBusWidth() bus width too large");
         }
         if(busWidth % 2) {
@@ -947,6 +947,11 @@ std::string admplug::ReaperAPIImpl::GetTrackStateChunkStr(MediaTrack* track) con
     if (!res) return std::string();
     std::string fullChunk{ chunk, strnlen(chunk, chunkMaxLen) };
     return fullChunk;
+}
+
+int admplug::ReaperAPIImpl::GetDawChannelCount() const
+{
+    return GetReaperChannelCount(GetAppVersion());
 }
 
 bool admplug::ReaperAPIImpl::TrackFX_GetActualFXName(MediaTrack* track, int fx, std::string& name) const

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.cpp
@@ -448,10 +448,6 @@ void* admplug::ReaperAPIImpl::GetSetTrackSendInfo(MediaTrack* tr, int category, 
     return ::GetSetTrackSendInfo(tr, category, sendidx, parmname, setNewValue);
 }
 
-bool admplug::ReaperAPIImpl::TrackFX_SetPinMappings(MediaTrack* tr, int fx, int isoutput, int pin, int low32bits, int hi32bits) const
-{
-    return ::TrackFX_SetPinMappings(tr, fx, isoutput, pin, low32bits, hi32bits);
-}
 int admplug::ReaperAPIImpl::GetEnvelopeScalingMode(TrackEnvelope * env) const
 {
     return ::GetEnvelopeScalingMode(env);
@@ -758,28 +754,6 @@ std::unique_ptr<Track> ReaperAPIImpl::masterTrack() const
 ReaProject* ReaperAPIImpl::getCurrentProject() const
 {
     return EnumProjects(-1, NULL, 0);
-}
-
-void admplug::ReaperAPIImpl::resetFxPinMap(MediaTrack * trk, int fxNum) const
-{
-    for(int pinNum = 0; pinNum < MAX_DAW_CHANNELS; pinNum++) {
-        mapFxPin(trk, fxNum, pinNum, pinNum);
-    }
-}
-
-void admplug::ReaperAPIImpl::mapFxPin(MediaTrack * trk, int fxNum, int trackChannel, int fxChannel) const
-{
-    if(trackChannel < 32) {
-        uint32_t low = TWO_TO_THE_POWER_OF(trackChannel);
-        TrackFX_SetPinMappings(trk, fxNum, 0, fxChannel, low, 0);
-        TrackFX_SetPinMappings(trk, fxNum, 1, fxChannel, low, 0);
-    } else if(trackChannel < 64) { // TODO - what about channels up to 128??
-        trackChannel -= 32;
-        uint32_t high = TWO_TO_THE_POWER_OF(trackChannel);
-        TrackFX_SetPinMappings(trk, fxNum, 0, fxChannel, 0, high);
-        TrackFX_SetPinMappings(trk, fxNum, 1, fxChannel, 0, high);
-    }
-
 }
 
 bool admplug::ReaperAPIImpl::forceAmplitudeScaling(TrackEnvelope * trackEnvelope) const

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.h
@@ -147,6 +147,7 @@ public:
     std::vector<std::pair<int, std::string>> GetVSTElementsFromTrackStateChunk(const std::string& fullChunk) const override;
     std::vector<std::string> SplitVSTElement(const std::string& elm, bool stripBoundingQuotes, bool includeSeperators) const override;
     std::string GetTrackStateChunkStr(MediaTrack* track) const override;
+    int GetDawChannelCount() const override;
 
 private:
     reaper_plugin_info_t& plugin_info;

--- a/reaper-adm-extension/src/reaper_adm/reaperapiimpl.h
+++ b/reaper-adm-extension/src/reaper_adm/reaperapiimpl.h
@@ -101,7 +101,6 @@ public:
     bool GetEnvelopeStateChunk(TrackEnvelope* env, char* strNeedBig, int strNeedBig_sz, bool isundoOptional) const override;
     bool SetEnvelopeStateChunk(TrackEnvelope* env, const char* str, bool isundoOptional ) const override;
     void* GetSetTrackSendInfo(MediaTrack* tr, int category, int sendidx, const char* parmname, void* setNewValue) const override;
-    bool TrackFX_SetPinMappings(MediaTrack* tr, int fx, int isoutput, int pin, int low32bits, int hi32bits) const override;
     int GetEnvelopeScalingMode(TrackEnvelope* env ) const override;
     double ScaleFromEnvelopeMode(int scaling_mode, double val ) const override;
     double ScaleToEnvelopeMode(int scaling_mode, double val ) const override;
@@ -138,8 +137,6 @@ public:
     std::unique_ptr<Track> createTrack(MediaTrack*) const override;
     std::unique_ptr<Track> masterTrack() const override;
     ReaProject* getCurrentProject() const override;
-    void resetFxPinMap(MediaTrack* trk, int fxNum) const override;
-    void mapFxPin(MediaTrack* trk, int fxNum, int trackChannel, int fxChannel) const override;
     bool forceAmplitudeScaling(TrackEnvelope * trackEnvelope) const override;
     std::optional<std::pair<double, double>> getTrackAudioBounds(MediaTrack* trk, bool ignoreBeforeZero) const override;
     bool TrackFX_GetActualFXName(MediaTrack* track, int fx, std::string& name) const override;

--- a/reaper-adm-extension/test/reaper_adm/acceptancetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/acceptancetests.cpp
@@ -18,6 +18,7 @@
 #include <track.h>
 #include <helper/container_helpers.hpp>
 #include <fstream>
+#include <global_config.h>
 
 using namespace admplug;
 using ::testing::_;
@@ -391,9 +392,9 @@ namespace {
             EXPECT_CALL(api, TrackFX_AddByActualName(fake.trackFor.renderer, StrEq(EAR_DEFAULT_MONITORING_PLUGIN_NAME), _, TrackFXAddMode::CreateNew));
         }
 
-        SECTION("Sets the number of track channels to 64, disables object and scene track master sends") {
-            EXPECT_CALL(api, setTrackChannelCount(fake.trackFor.renderer, 64)).Times(1);
-            EXPECT_CALL(api, setTrackChannelCount(fake.trackFor.submix, 64)).Times(1);
+        SECTION("Sets the number of track channels to MAX_DAW_CHANNELS, disables object and scene track master sends") {
+            EXPECT_CALL(api, setTrackChannelCount(fake.trackFor.renderer, MAX_DAW_CHANNELS)).Times(1);
+            EXPECT_CALL(api, setTrackChannelCount(fake.trackFor.submix, MAX_DAW_CHANNELS)).Times(1);
             for(int i = 0; i < expectedTracks; ++i) {
                 EXPECT_CALL(api, setTrackChannelCount(fake.generatedTracks[i], _)).Times(1);
                 EXPECT_CALL(api, disableTrackMasterSend(fake.generatedTracks[i])).Times(1);
@@ -406,7 +407,7 @@ namespace {
             for(int i = 0; i < expectedTracks; ++i) {
                 EXPECT_CALL(api, RouteTrackToTrack(fake.generatedTracks[i],_,fake.trackFor.submix,_,_,_,_)).Times(1);
             }
-            EXPECT_CALL(api, RouteTrackToTrack(fake.trackFor.submix,_,fake.trackFor.renderer,_,64,_,_)).Times(1);
+            EXPECT_CALL(api, RouteTrackToTrack(fake.trackFor.submix,_,fake.trackFor.renderer,_, MAX_DAW_CHANNELS,_,_)).Times(1);
         }
 
         SECTION("Adds audio to the track") {

--- a/reaper-adm-extension/test/reaper_adm/acceptancetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/acceptancetests.cpp
@@ -138,7 +138,8 @@ namespace {
     };
 
     void setApiDefaults(MockReaperAPI& api, FakeReaperObjects& fake) {
-
+        ON_CALL(api, GetAppVersion()).WillByDefault(Return("7.0"));
+        ON_CALL(api, GetDawChannelCount()).WillByDefault(Return(MAX_DAW_CHANNELS));
         ON_CALL(api, GetResourcePath()).WillByDefault(Return("data"));
         ON_CALL(api, PCM_Source_CreateFromFile(_)).WillByDefault(Return(fake.source));
         ON_CALL(api, AddMediaItemToTrack(_)).WillByDefault([&api, &fake](MediaTrack* tr){

--- a/reaper-adm-extension/test/reaper_adm/acceptancetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/acceptancetests.cpp
@@ -18,7 +18,7 @@
 #include <track.h>
 #include <helper/container_helpers.hpp>
 #include <fstream>
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 using namespace admplug;
 using ::testing::_;

--- a/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
@@ -16,7 +16,7 @@
 #include "hoaautomationelement.h"
 #include "mediatakeelement.h"
 #include "mediatrackelement.h"
-#include <global_config.h>
+#include <daw_channel_count.h>
 
 #define TRACK_MAPPING_PARAM_INDEX 0
 #define TRACK_MAPPING_PARAM_MAXVAL MAX_DAW_CHANNELS

--- a/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
@@ -16,9 +16,10 @@
 #include "hoaautomationelement.h"
 #include "mediatakeelement.h"
 #include "mediatrackelement.h"
+#include <global_config.h>
 
 #define TRACK_MAPPING_PARAM_INDEX 0
-#define TRACK_MAPPING_PARAM_MAXVAL 64
+#define TRACK_MAPPING_PARAM_MAXVAL MAX_DAW_CHANNELS
 
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -192,14 +193,14 @@ TEST_CASE("On first create project, scene master and renderer added") {
     earSuite.onCreateProject(node, api);
 }
 
-TEST_CASE("On first create project, bus and renderer tracks set to 64 channels") {
+TEST_CASE("On first create project, bus and renderer tracks set to MAX_DAW_CHANNELS channels") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
     auto project = std::make_shared<NiceMock<MockProjectElement>>();
     auto node = ProjectNode{project};
 
     auto returnTrackWithPluginExpectations = createTrack([](MockTrack& track){
-        EXPECT_CALL(track, setChannelCount(64));
+        EXPECT_CALL(track, setChannelCount(MAX_DAW_CHANNELS));
     });
 
     ON_CALL(api, createTrack()).WillByDefault(returnTrackWithPluginExpectations);

--- a/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
+++ b/reaper-adm-extension/test/reaper_adm/earsuitetests.cpp
@@ -40,6 +40,11 @@ namespace {
 
 FakePtrFactory fakePtr;
 
+void setApiDefaults(MockReaperAPI& api) {
+    ON_CALL(api, GetAppVersion()).WillByDefault(Return("7.0"));
+    ON_CALL(api, GetDawChannelCount()).WillByDefault(Return(MAX_DAW_CHANNELS));
+}
+
 auto getPluginStr = [](std::string){
     return std::make_unique<NiceMock<MockPlugin>>();
 };
@@ -169,6 +174,7 @@ MATCHER_P(HasIndex, index, "")
 TEST_CASE("On create project, two tracks are created") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
     auto project = std::make_shared<NiceMock<MockProjectElement>>();
     auto node = ProjectNode{project};
     EXPECT_CALL(api, createTrack()).Times(2).WillRepeatedly(createDefaultTrack);
@@ -178,6 +184,7 @@ TEST_CASE("On create project, two tracks are created") {
 TEST_CASE("On first create project, scene master and renderer added") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
     auto project = std::make_shared<NiceMock<MockProjectElement>>();
     auto node = ProjectNode{project};
 
@@ -196,6 +203,7 @@ TEST_CASE("On first create project, scene master and renderer added") {
 TEST_CASE("On first create project, bus and renderer tracks set to MAX_DAW_CHANNELS channels") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
     auto project = std::make_shared<NiceMock<MockProjectElement>>();
     auto node = ProjectNode{project};
 
@@ -210,6 +218,7 @@ TEST_CASE("On first create project, bus and renderer tracks set to MAX_DAW_CHANN
 TEST_CASE("On first create project, bus track has master send disabled") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
     EXPECT_CALL(api, disableTrackMasterSend(_)).Times(1);
     auto node = initProject(earSuite, api);
     earSuite.onCreateProject(node, api);
@@ -218,6 +227,7 @@ TEST_CASE("On first create project, bus track has master send disabled") {
 TEST_CASE("On subsequent create project, scene master and renderer not added") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
 
     auto smTrack = createTrack([](MockTrack& track){
         ON_CALL(track, stillExists()).WillByDefault(Return(true));
@@ -257,6 +267,7 @@ TEST_CASE("On subsequent create project, scene master and renderer not added") {
 TEST_CASE("Bus and renderer tracks positioned") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
     auto project = std::make_shared<NiceMock<MockProjectElement>>();
     auto node = ProjectNode{project};
     auto mediaPosition{7};
@@ -286,6 +297,7 @@ TEST_CASE("Bus and renderer tracks positioned") {
 TEST_CASE("Object tracks created and plugin instantiated") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
 
     auto ao = adm::AudioObject::create(adm::AudioObjectName("test"));
     auto atu = adm::AudioTrackUid::create();
@@ -455,6 +467,7 @@ TEST_CASE("Object tracks created and plugin instantiated") {
 TEST_CASE("Object tracks are routed to scene, and not sent to master") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
 
     auto ao = adm::AudioObject::create(adm::AudioObjectName("test"));
     auto atu = adm::AudioTrackUid::create();
@@ -480,6 +493,7 @@ TEST_CASE("Object tracks are routed to scene, and not sent to master") {
 TEST_CASE("Directspeaker tracks are created and configured") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
 
     auto ao = adm::AudioObject::create(adm::AudioObjectName("test"));
     auto apf = adm::AudioPackFormat::create(adm::AudioPackFormatName("test"), adm::TypeDefinition::DIRECT_SPEAKERS, adm::parseAudioPackFormatId("AP_00010002"));
@@ -548,6 +562,7 @@ TEST_CASE("Directspeaker tracks are created and configured") {
 TEST_CASE("HOA tracks are created and configured") {
     EARPluginSuite earSuite;
     auto api = NiceMock<MockReaperAPI>{};
+    setApiDefaults(api);
 
     auto ao = adm::AudioObject::create(adm::AudioObjectName("test"));
     auto apf = admCommonDef->lookup(adm::parseAudioPackFormatId("AP_00040001"));

--- a/reaper-adm-extension/test/reaper_adm/mocks/reaperapi.h
+++ b/reaper-adm-extension/test/reaper_adm/mocks/reaperapi.h
@@ -239,7 +239,7 @@ class MockReaperAPI : public ReaperAPI {
   MOCK_CONST_METHOD1(GetVSTElementsFromTrackStateChunk, std::vector<std::pair<int, std::string>>(const std::string& fullChunk));
   MOCK_CONST_METHOD3(SplitVSTElement, std::vector<std::string>(const std::string& elm, bool stripBoundingQuotes, bool includeSeperators));
   MOCK_CONST_METHOD1(GetTrackStateChunkStr, std::string(MediaTrack* track));
-
+  MOCK_CONST_METHOD0(GetDawChannelCount, int());
 };
 
 }  // namespace admplug

--- a/shared/components/ear_combo_box.cpp
+++ b/shared/components/ear_combo_box.cpp
@@ -19,6 +19,11 @@ EarComboBoxEntry::EarComboBoxEntry(int id) : id_{ id } {
 }
 
 bool EarComboBoxEntry::isSelectable() const { return isSelectable_; }
+void EarComboBoxEntry::setSelectable(bool selectable)
+{
+	isSelectable_ = selectable;
+	repaint();
+}
 bool EarComboBoxEntry::isSelected() const { return selected_; }
 void EarComboBoxEntry::setSelected(bool selected) { selected_ = selected; }
 
@@ -58,7 +63,12 @@ String EarComboBoxTextEntry::getText() const { return text_; }
 
 void EarComboBoxTextEntry::drawEntryInList(Graphics& g,
 	juce::Rectangle<int> area) {
-	g.setColour(findColour(textColourId));
+	if (isSelectable_) {
+		g.setColour(findColour(textColourId));
+	}
+	else {
+		g.setColour(findColour(textColourId).withBrightness(0.5));
+	}
 	g.setFont(EarFontsSingleton::instance().Items);
 	g.drawText(text_, area.withTrimmedLeft(14).withTrimmedRight(14),
 		Justification::left);

--- a/shared/components/ear_combo_box.cpp
+++ b/shared/components/ear_combo_box.cpp
@@ -502,20 +502,31 @@ void EarComboBox::setDefaultText(const String& text) {
 }
 String EarComboBox::getDefaultText() const { return defaultText_; }
 
-void EarComboBox::addEntry(std::unique_ptr<EarComboBoxEntry> entry) {
+EarComboBoxEntry* EarComboBox::addEntry(std::unique_ptr<EarComboBoxEntry> entry) {
+	auto rawptr = entry.get();
 	popup_->addEntry(std::move(entry));
+	return rawptr;
 }
 
-void EarComboBox::addTextEntry(const String& text, int id) {
-	addEntry(std::make_unique<EarComboBoxTextEntry>(text, id));
+EarComboBoxTextEntry* EarComboBox::addTextEntry(const String& text, int id) {
+	auto uptr = std::make_unique<EarComboBoxTextEntry>(text, id);
+	auto rawptr = uptr.get();
+	addEntry(std::move(uptr));
+	return rawptr;
 }
 
-void EarComboBox::addColourEntry(const Colour& colour, int id) {
-	addEntry(std::make_unique<EarComboBoxColourEntry>(colour, id));
+EarComboBoxColourEntry* EarComboBox::addColourEntry(const Colour& colour, int id) {
+	auto uptr = std::make_unique<EarComboBoxColourEntry>(colour, id);
+	auto rawptr = uptr.get();
+	addEntry(std::move(uptr));
+	return rawptr;
 }
 
-void EarComboBox::addSectionEntry(const String& text, int id) {
-	addEntry(std::make_unique<EarComboBoxSectionEntry>(text, id));
+EarComboBoxSectionEntry* EarComboBox::addSectionEntry(const String& text, int id) {
+	auto uptr = std::make_unique<EarComboBoxSectionEntry>(text, id);
+	auto rawptr = uptr.get();
+	addEntry(std::move(uptr));
+	return rawptr;
 }
 
 void EarComboBox::clearEntries() {

--- a/shared/components/ear_combo_box.hpp
+++ b/shared/components/ear_combo_box.hpp
@@ -415,6 +415,10 @@ public:
 		}
 	}
 
+	EarComboBoxPopup* getPopup() {
+		return popup_.get();
+	}
+
 	std::function<void(int)> onValueChange;
 
 	class Listener {

--- a/shared/components/ear_combo_box.hpp
+++ b/shared/components/ear_combo_box.hpp
@@ -20,6 +20,7 @@ public:
 	bool isSelected() const;
 	void setSelected(bool selected);
 	bool isSelectable() const;
+	void setSelectable(bool selectable);
 	bool isHighlighted() const;
 	void setHighlighted(bool highlighted);
 

--- a/shared/components/ear_combo_box.hpp
+++ b/shared/components/ear_combo_box.hpp
@@ -159,13 +159,22 @@ public:
 		return -1;
 	}
 
-	int getEntryById(int id) {
+	int getEntryIndexById(int id) {
 		for (int i = 0; i < entries_.size(); ++i) {
 			if (entries_.at(i)->getId() == id) {
 				return i;
 			}
 		}
 		return -1;
+	}
+
+	EarComboBoxEntry* getEntryById(int id) {
+		for (int i = 0; i < entries_.size(); ++i) {
+			if (entries_.at(i)->getId() == id) {
+				return entries_.at(i).get();
+			}
+		}
+		return nullptr;
 	}
 
 	void show();
@@ -339,7 +348,7 @@ public:
 	bool hasSelection() { return getSelectedEntryIndex() >= 0; }
 
 	bool setSelectedId(int id, NotificationType notification) {
-		auto index = popup_->getEntryById(id);
+		auto index = popup_->getEntryIndexById(id);
 		if (index < 0) return false;
 		selectEntry(index, notification);
 		return true;

--- a/shared/components/ear_combo_box.hpp
+++ b/shared/components/ear_combo_box.hpp
@@ -322,10 +322,10 @@ public:
 	void setDefaultText(const String& text);
 	String getDefaultText() const;
 
-	void addEntry(std::unique_ptr<EarComboBoxEntry> entry);
-	void addTextEntry(const String& text, int id = 0);
-	void addColourEntry(const Colour& colour, int id = 0);
-	void addSectionEntry(const String& text, int id = 0);
+	EarComboBoxEntry* addEntry(std::unique_ptr<EarComboBoxEntry> entry);
+	EarComboBoxTextEntry* addTextEntry(const String& text, int id = 0);
+	EarComboBoxColourEntry* addColourEntry(const Colour& colour, int id = 0);
+	EarComboBoxSectionEntry* addSectionEntry(const String& text, int id = 0);
 
 	void selectEntry(int newIndex, NotificationType notification) {
 		if (newIndex != currentSelectedIndex_) {

--- a/shared/components/look_and_feel/tooltips.hpp
+++ b/shared/components/look_and_feel/tooltips.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "JuceHeader.h"
+#include "colours.hpp"
 
 namespace ear {
 namespace plugin {

--- a/shared/components/onboarding.hpp
+++ b/shared/components/onboarding.hpp
@@ -88,8 +88,9 @@ class Onboarding : public Component {
         "Create object-based audioscenes and listen to your project.\n\n",
         font::RobotoSingleton::instance().getMedium(17.f));
     slide4Text.append(
-        "Route all 64 channels of the EAR Scene into the EAR Monitoring plugin "
-        "with the setup of your choice. Set the hardware routing in the EAR "
+        "Route all channels of the EAR Scene into the EAR Monitoring plugin "
+        "with the setup of your choice. This may be 64 or 128 channels "
+        "depending on your DAW version. Set the hardware routing in the EAR "
         "Monitoring track according to your monitoring setup.",
         font::RobotoSingleton::instance().getRegular(16.f));
     slide4Text.setColour(EarColours::Text);

--- a/shared/daw_channel_count.h
+++ b/shared/daw_channel_count.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define MAX_DAW_CHANNELS 128

--- a/shared/daw_channel_count.h
+++ b/shared/daw_channel_count.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <functional>
 #include <cassert>
 
 #define MAX_DAW_CHANNELS 128

--- a/shared/daw_channel_count.h
+++ b/shared/daw_channel_count.h
@@ -1,3 +1,33 @@
 #pragma once
+#include <functional>
+#include <cassert>
 
 #define MAX_DAW_CHANNELS 128
+
+inline int GetReaperChannelCount(float reaperAppVersionFlt) {
+    return reaperAppVersionFlt >= 7.0f ? 128 : 64;
+}
+
+inline int GetReaperChannelCount(const char* reaperAppVersion) {
+    if (!reaperAppVersion) {
+        return MAX_DAW_CHANNELS;
+    }
+    try {
+        auto reaperAppVersionFlt = std::stof(reaperAppVersion);
+        return GetReaperChannelCount(reaperAppVersionFlt);
+    }
+    catch (const std::logic_error& e) {
+        // catches nullptr and invalid arg to stof
+        assert(false); // just to warn when in debug
+    }
+    return MAX_DAW_CHANNELS; // Couldn't parse version - let's assume 128 since older versions we tested on all seem parsable
+}
+
+inline int GetReaperChannelCount(void* reaperApiGetAppVersionFuncPtr) {
+    if (!reaperApiGetAppVersionFuncPtr) {
+        return MAX_DAW_CHANNELS;
+    }
+    const char* GetAppVersionSig();
+    auto getAppVersion = reinterpret_cast<decltype(&GetAppVersionSig)>(reaperApiGetAppVersionFuncPtr);
+    return GetReaperChannelCount(getAppVersion());
+}

--- a/shared/global_config.h
+++ b/shared/global_config.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define MAX_DAW_CHANNELS 128

--- a/shared/global_config.h
+++ b/shared/global_config.h
@@ -1,3 +1,0 @@
-#pragma once
-
-#define MAX_DAW_CHANNELS 128


### PR DESCRIPTION
Implements 128 channel support in EPS.

Extension will use 128 channels during import if REAPER version >=7.0, otherwise it continues to use 64 channels.
Export code supports 128 channels throughout since it will only use as many channels as necessary for the project anyway (and so is self-limiting since nothing can be routed to channels above 64 in REAPER <v7)

Plugins are fixed to 128 channels but will disable channel selection >64 if running in REAPER and the REAPER version <7.0

Closes #244 