### PR TITLE
Fix monitoring for objects sharing input audio 

### DIFF
--- a/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
@@ -19,7 +19,7 @@ struct GainHolder {
   Eigen::MatrixXf diffuse;
 };
 
-struct ItemRouting {
+struct ItemGains {
   int inputStartingChannel;
   int inputChannelCount;
   std::vector<std::vector<float>> direct_;
@@ -44,7 +44,7 @@ class SceneGainsCalculator {
   ear::GainCalculatorDirectSpeakers directSpeakersCalculator_;
   ear::GainCalculatorHOA hoaCalculator_;
 
-  std::map<communication::ConnectionId, ItemRouting> routingCache_;
+  std::map<communication::ConnectionId, ItemGains> routingCache_;
 
   std::mutex commonDefinitionHelperMutex_;
   AdmCommonDefinitionHelper commonDefinitionHelper_{};

--- a/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
@@ -22,6 +22,8 @@ struct GainHolder {
 struct ItemRouting {
   int inputStartingChannel;
   int inputChannelCount;
+  std::vector<std::vector<float>> direct_;
+  std::vector<std::vector<float>> diffuse_;
 };
 
 class SceneGainsCalculator {
@@ -32,12 +34,11 @@ class SceneGainsCalculator {
   Eigen::MatrixXf diffuseGains();
 
  private:
-  void resize(ear::Layout &ouputLayout, std::size_t inputChannelCount);
+  int totalOutputChannels;
+  int totalInputChannels;
+
   void removeItem(const communication::ConnectionId &itemId);
   void addOrUpdateItem(const proto::MonitoringItemMetadata &item);
-
-  std::vector<std::vector<float>> direct_;
-  std::vector<std::vector<float>> diffuse_;
 
   ear::GainCalculatorObjects objectCalculator_;
   ear::GainCalculatorDirectSpeakers directSpeakersCalculator_;

--- a/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
@@ -21,7 +21,6 @@ struct GainHolder {
 
 struct ItemGains {
   int inputStartingChannel;
-  int inputChannelCount;
   std::vector<std::vector<float>> direct_;
   std::vector<std::vector<float>> diffuse_;
 };

--- a/ear-production-suite-plugins/lib/include/scene_store.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_store.hpp
@@ -49,7 +49,6 @@ private:
     void addGroup(proto::ProgrammeElement const& element);
     void addToggle(proto::ProgrammeElement const& element);
     void sendUpdate();
-    void flagOverlaps();
 };
 }
 

--- a/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
@@ -9,12 +9,12 @@
 namespace {
 
 Eigen::MatrixXf toEigenMat(std::vector<std::vector<float>>& vec) {
-  auto outputCount = vec.size();
-  auto inputCount = static_cast<int>(vec[0].size());
-  Eigen::MatrixXf mat(inputCount, outputCount);
-  for (std::size_t i = 0; i < outputCount; i++) {
-    mat.col(static_cast<int>(i)) =
-      Eigen::VectorXf::Map(vec[i].data(), inputCount);
+  auto totalInputs = vec.size();
+  auto totalOutputs = static_cast<int>(vec[0].size());
+  Eigen::MatrixXf mat(totalOutputs, totalInputs);
+  for (int inputChannel = 0; inputChannel < totalInputs; inputChannel++) {
+    mat.col(inputChannel) =
+      Eigen::VectorXf::Map(vec[inputChannel].data(), totalOutputs);
   }
   return mat;
 }

--- a/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
@@ -116,7 +116,7 @@ void SceneGainsCalculator::removeItem(const communication::ConnectionId &itemId)
 
 void SceneGainsCalculator::addOrUpdateItem(const proto::MonitoringItemMetadata & item)
 {
-  ItemRouting* routing = setInMap(routingCache_, communication::ConnectionId{ item.connection_id() }, {});
+  ItemGains* routing = setInMap(routingCache_, communication::ConnectionId{ item.connection_id() }, {});
 
   if(item.has_ds_metadata()) {
     auto earMetadata = EpsToEarMetadataConverter::convert(item.ds_metadata());

--- a/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
@@ -86,7 +86,11 @@ bool SceneGainsCalculator::update(proto::SceneStore store) {
 Eigen::MatrixXf SceneGainsCalculator::directGains() {
   Eigen::MatrixXf mat = Eigen::MatrixXf::Zero(totalOutputChannels, totalInputChannels);
   for (auto const& [itemId, routing] : routingCache_) {
-    addToEigenMat(mat, routing.direct_, routing.inputStartingChannel);
+    if (routing.inputStartingChannel >= 0 &&
+        (routing.inputStartingChannel + routing.inputChannelCount) <
+            totalInputChannels) {
+      addToEigenMat(mat, routing.direct_, routing.inputStartingChannel);
+    }
   }
   return mat;
 }
@@ -94,7 +98,11 @@ Eigen::MatrixXf SceneGainsCalculator::directGains() {
 Eigen::MatrixXf SceneGainsCalculator::diffuseGains() {
   Eigen::MatrixXf mat = Eigen::MatrixXf::Zero(totalOutputChannels, totalInputChannels);
   for (auto const& [itemId, routing] : routingCache_) {
-    addToEigenMat(mat, routing.diffuse_, routing.inputStartingChannel);
+    if (routing.inputStartingChannel >= 0 &&
+        (routing.inputStartingChannel + routing.inputChannelCount) <
+            totalInputChannels) {
+      addToEigenMat(mat, routing.diffuse_, routing.inputStartingChannel);
+    }
   }
   return mat;
 }

--- a/ear-production-suite-plugins/lib/src/scene_store.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_store.cpp
@@ -33,8 +33,6 @@ void SceneStore::dataReset(const ear::plugin::proto::ProgrammeStore &programmes,
             }
         }
     }
-
-    flagOverlaps();
 }
 
 void ear::plugin::SceneStore::programmeSelected(const ear::plugin::ProgrammeObjects &objects) {
@@ -46,7 +44,6 @@ void ear::plugin::SceneStore::programmeSelected(const ear::plugin::ProgrammeObje
     for(auto const& object : objects) {
         addMonitoringItem(object.inputMetadata);
     }
-    flagOverlaps();
 }
 
 void ear::plugin::SceneStore::itemsAddedToProgramme(ear::plugin::ProgrammeStatus status,
@@ -55,7 +52,6 @@ void ear::plugin::SceneStore::itemsAddedToProgramme(ear::plugin::ProgrammeStatus
         for (auto const &object: objects) {
             addMonitoringItem(object.inputMetadata);
         }
-        flagOverlaps();
     }
 }
 
@@ -78,7 +74,6 @@ void ear::plugin::SceneStore::itemRemovedFromProgramme(ear::plugin::ProgrammeSta
                 item != monitoringItems->end()) {
             monitoringItems->erase(item);
             itemsChangedSinceLastSend.insert(id);
-            flagOverlaps();
         }
     }
 }
@@ -89,9 +84,6 @@ bool SceneStore::updateMonitoringItem(proto::InputItemMetadata const& inputItem)
             item != monitoringItems->end()) {
         auto routingChanged = item->routing() != inputItem.routing();
         setMonitoringItemFrom(*item, inputItem);
-        if(routingChanged) {
-            flagOverlaps();
-        }
         return true;
     } else {
         return false;
@@ -103,7 +95,6 @@ void ear::plugin::SceneStore::programmeItemUpdated(ear::plugin::ProgrammeStatus 
     if(status.isSelected) {
         if(!updateMonitoringItem(object.inputMetadata)) {
             addMonitoringItem(object.inputMetadata);
-            flagOverlaps();
         }
     }
 }
@@ -247,10 +238,3 @@ void SceneStore::exporting(bool isExporting) {
     }
 }
 
-void SceneStore::flagOverlaps() {
-  // Keep it simple - for any routing/monitoring mix changes
-  // Set changed on all items
-  for(auto& item : store_.all_available_items()) {
-    itemsChangedSinceLastSend.insert(item.connection_id());
-  }
-}


### PR DESCRIPTION
**Original issue;**
The `SceneGainsCalculator` class just kept a single pair of gains tables (vector of vectors, one for diffuse and one for direct feeds) for all items (i.e, AudioObjects).  
The `SceneGainsCalculator::update` method would iterate through all items in the store and run the `addOrUpdateItem` method to set the gains for the item in the gains tables (`direct_` and `diffuse_` members). Likewise the `removeItem` method would zero affected entries in the tables. Due to this "overwrite" behaviour, it meant that input sharing between objects was not possible. The last item to be processed in the store would overwrite gains set by any previous item which is also using those input channels.

**Solution:**
Each item keeps it's own pair of gains tables in the existing `ItemRouting` struct. These tables are only big enough for the item channel count for efficiency, rather than being sized to fit the total input and output channel count. When the backend requests the gain matrices, these are built at the point of request by summing all of the gain tables for all of the items in to an Eigen::MatrixXf which is initialised to zero, using the `addToEigenMat` free func. Note that the input channels when summing in to the matrix are offset by the starting channel number of the item.
This isolation of gains tables means we don't need to concern ourselves with what other items might be affected when the routing of one item changes, because their tables are calculated independently. This means we can get rid of the `flagOverlaps` which would previously set all items to "changed" to ensure the entire gains table was rebuilt.

Note that the first commit of this PR corrects some terminology (var names) in existing code before work commenced as it led to some confusion when implementing the new system.

Closes #257 