### PR TITLE
Third-Party Plugin Support Deprecation Warning

### DIFF
--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsourcescontainer.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsourcescontainer.cpp
@@ -67,6 +67,10 @@ std::vector<std::string> AdmExportHandler::generateExportWarningStrings()
     auto admExportSources = getAdmExportSources();
     std::vector<std::string> msgs;
 
+    if (admExportVstSources) {
+        msgs.push_back(std::string("Support for FB360 and VISR plugin suites will be dropped in future versions of the EAR Production Suite."));
+    }
+
     if(earSceneMasterVstSources && earSceneMasterVstSources->validForExport() && admExportVstSources && admExportVstSources->validForExport()) {
         msgs.push_back(std::string("Multiple Types of Export Source!"));
     }

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsourcescontainer.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsourcescontainer.cpp
@@ -3,6 +3,7 @@
 
 #include "exportaction_admsource-admvst.h"
 #include "exportaction_admsource-earvst.h"
+#include "plugin_deprecation_warning.h"
 
 void AdmExportHandler::repopulate(ReaperAPI const & api)
 {
@@ -68,7 +69,7 @@ std::vector<std::string> AdmExportHandler::generateExportWarningStrings()
     std::vector<std::string> msgs;
 
     if (admExportVstSources) {
-        msgs.push_back(std::string("Support for FB360 and VISR plugin suites will be dropped in future versions of the EAR Production Suite."));
+        msgs.push_back(pluginDeprecationMessage);
     }
 
     if(earSceneMasterVstSources && earSceneMasterVstSources->validForExport() && admExportVstSources && admExportVstSources->validForExport()) {

--- a/reaper-adm-extension/src/reaper_adm/exportaction_admsourcescontainer.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_admsourcescontainer.cpp
@@ -68,7 +68,7 @@ std::vector<std::string> AdmExportHandler::generateExportWarningStrings()
     auto admExportSources = getAdmExportSources();
     std::vector<std::string> msgs;
 
-    if (admExportVstSources) {
+    if (admExportVstSources && admExportVstSources->getAllFoundVsts()->size() > 0) {
         msgs.push_back(pluginDeprecationMessage);
     }
 

--- a/reaper-adm-extension/src/reaper_adm/plugin_deprecation_warning.h
+++ b/reaper-adm-extension/src/reaper_adm/plugin_deprecation_warning.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "reaperapi.h"
+#include "pluginsuite.h"
+#include <string>
+#include <map>
+
+const std::string pluginDeprecationMessage{
+    "Support for FB360 and VISR plugin suites will be dropped in future versions of the EAR Production Suite." };
+
+inline void pluginDeprecationWarning(const std::pair<std::string, std::shared_ptr<PluginSuite>>& pluginSuite, ReaperAPI& api) {
+    if (pluginSuite.first != std::string("EAR")) { // a bit hacky, but this won't be in long-term so meh
+        std::string msgboxText{ "Please note:\n" };
+        msgboxText += pluginDeprecationMessage;
+        api.ShowMessageBox(msgboxText.c_str(), "ADM Open", 0);
+    }
+}

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -12,6 +12,7 @@
 #include "pluginsuite.h"
 #include "pluginregistry.h"
 #include "pluginsuite_ear.h"
+#include "plugin_deprecation_warning.h"
 #include <update_check.h>
 #include <version/eps_version.h>
 #include <helper/native_message_box.hpp>
@@ -50,15 +51,6 @@ const std::map<const std::string, const int> defaultMenuPositions = {
     {"Group", 4}};
 }
 #endif
-
-void pluginDeprecationWarning(const std::pair<std::string, std::shared_ptr<PluginSuite>>& pluginSuite, ReaperAPI& api) {
-    if (pluginSuite.first != std::string("EAR")) { // a bit hacky, but this won't be in long-term so meh
-        api.ShowMessageBox(
-            "Please note:\nSupport for FB360 and VISR plugin suites will" 
-            " be dropped in future versions of the EAR Production Suite.", 
-            "ADM Open", 0);
-    }
-}
 
 extern "C" {
 

--- a/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
+++ b/reaper-adm-extension/src/reaper_adm/pluginmain.cpp
@@ -51,6 +51,15 @@ const std::map<const std::string, const int> defaultMenuPositions = {
 }
 #endif
 
+void pluginDeprecationWarning(const std::pair<std::string, std::shared_ptr<PluginSuite>>& pluginSuite, ReaperAPI& api) {
+    if (pluginSuite.first != std::string("EAR")) { // a bit hacky, but this won't be in long-term so meh
+        api.ShowMessageBox(
+            "Please note:\nSupport for FB360 and VISR plugin suites will" 
+            " be dropped in future versions of the EAR Production Suite.", 
+            "ADM Open", 0);
+    }
+}
+
 extern "C" {
 
   uint32_t requestInputInstanceId() {
@@ -296,6 +305,8 @@ extern "C" {
             std::make_unique<ImportAction>(hInstance, rec->hwnd_main, pluginSuite.second),
             [pluginSuite](ReaperAPI& api, ImportAction& importer) {
 
+            pluginDeprecationWarning(pluginSuite, api);
+
             api.Main_openProject("template:"); // This will TRY to start a blank project, but it will replace the current project if successful, so the user is prompted with the save dialog: yes, no, CANCEL
             auto res = api.IsProjectDirty(nullptr); // If the project is still dirty (1), the user must have canceled! (yes/no would save/not save and start a new clean project)
             if(res == 0) {
@@ -350,6 +361,8 @@ extern "C" {
             actionSID.c_str(),
             std::make_unique<ImportAction>(hInstance, rec->hwnd_main, pluginSuite.second),
             [pluginSuite](ReaperAPI& api, ImportAction& importer) {
+
+            pluginDeprecationWarning(pluginSuite, api);
 
             char filename[4096];
             api.GetProjectPath(filename, 4096);


### PR DESCRIPTION
Warns user that support for third-party plugin suites will be dropped in future versions. Message is shown when the user imports ADM using a third-party plugin suite in to a new project or in to an existing project. Warning also shows in the render dialog when "ADM" output format is selected and instances of the ADM Export Source VST are found.

This has been mainly implemented in it's own header so we can easily strip it out and make sure we don't leave anything behind (compiler will point out all the affected bits of code once the header is deleted).