### PR TITLE
Fix backwards compatibility with 64ch REAPER versions

### DIFF
--- a/ear-production-suite-plugins/plugins/binaural_monitoring/src/binaural_monitoring_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/binaural_monitoring/src/binaural_monitoring_plugin_processor.cpp
@@ -9,6 +9,8 @@
 #include "reaper_vst3_interfaces.h"
 #include "reaper_integration.hpp"
 
+#include <cassert>
+
 #define DEFAULT_OSC_PORT 8000
 
 namespace ear {
@@ -519,6 +521,7 @@ void EarBinauralMonitoringAudioProcessor::setIHostApplication(
         true, 0, AudioChannelSet::discreteChannels(numDawChannels_));
     auto retO = setChannelLayoutOfBus(
         false, 0, AudioChannelSet::discreteChannels(numDawChannels_));
+    assert(retI && retO);
     backend_ = std::make_unique<ear::plugin::BinauralMonitoringBackend>(
         nullptr, numDawChannels_);
     connector_->setListenerOrientationInstance(backend_->listenerOrientation);

--- a/ear-production-suite-plugins/plugins/binaural_monitoring/src/binaural_monitoring_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/binaural_monitoring/src/binaural_monitoring_plugin_processor.hpp
@@ -12,6 +12,8 @@
 #include "bear_data_files.hpp"
 #include "orientation_osc.hpp"
 
+#include <daw_channel_count.h>
+
 namespace ear {
 namespace plugin {
 namespace ui {
@@ -26,7 +28,8 @@ class BinauralMonitoringAudioProcessor;
 class EarBinauralMonitoringAudioProcessor
     : private AudioProcessorParameter::Listener,
       Timer,
-      public AudioProcessor {
+      public AudioProcessor,
+      public VST3ClientExtensions {
  public:
   EarBinauralMonitoringAudioProcessor();
   ~EarBinauralMonitoringAudioProcessor();
@@ -58,6 +61,8 @@ class EarBinauralMonitoringAudioProcessor
 
   void getStateInformation(MemoryBlock& destData) override;
   void setStateInformation(const void* data, int sizeInBytes) override;
+
+  void setIHostApplication(Steinberg::FUnknown* unknown) override;
 
   std::weak_ptr<ear::plugin::LevelMeterCalculator> getLevelMeter() {
     return levelMeter_;
@@ -93,8 +98,6 @@ class EarBinauralMonitoringAudioProcessor
   void timerCallback() override;
 
  private:
-  BusesProperties _getBusProperties();
-
   AudioParameterBool* bypass_;
   AudioParameterFloat* yaw_;
   AudioParameterFloat* pitch_;
@@ -119,6 +122,7 @@ class EarBinauralMonitoringAudioProcessor
 
   int samplerate_{48000};
   int blocksize_{512};
+  int numDawChannels_{MAX_DAW_CHANNELS};
 
   std::shared_ptr<ear::plugin::LevelMeterCalculator> levelMeter_;
 

--- a/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.cpp
@@ -5,6 +5,8 @@
 #include "reaper_vst3_interfaces.h"
 #include "reaper_integration.hpp"
 
+#include <cassert>
+
 namespace ear {
 namespace plugin {
 template <>
@@ -63,6 +65,7 @@ void EarMonitoringAudioProcessor::setIHostApplication(
           true, 0, AudioChannelSet::discreteChannels(numDawChannels_));
       auto retO = setChannelLayoutOfBus(
           false, 0, AudioChannelSet::discreteChannels(numDawChannels_));
+      assert(retI && retO);
       backend_ = std::make_unique<ear::plugin::MonitoringBackend>(
           nullptr, layout(), numDawChannels_);
     }

--- a/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/monitoring/src/monitoring_plugin_processor.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "components/level_meter_calculator.hpp"
+#include <daw_channel_count.h>
 
 namespace ear {
 namespace plugin {
@@ -33,7 +34,8 @@ inline bool operator!=(ProcessorConfig const& lhs, ProcessorConfig const rhs) {
   return !(lhs == rhs);
 }
 
-class EarMonitoringAudioProcessor : public AudioProcessor {
+class EarMonitoringAudioProcessor : public AudioProcessor,
+                                    public VST3ClientExtensions {
  public:
   EarMonitoringAudioProcessor();
   ~EarMonitoringAudioProcessor();
@@ -70,15 +72,17 @@ class EarMonitoringAudioProcessor : public AudioProcessor {
     return levelMeter_;
   };
 
+  void setIHostApplication(Steinberg::FUnknown* unknown) override;
+
  private:
-  BusesProperties _getBusProperties();
   void configureProcessor(const ProcessorConfig& config);
   ProcessorConfig processorConfig_{};
   std::unique_ptr<ear::plugin::MonitoringBackend> backend_;
   std::unique_ptr<ear::plugin::MonitoringAudioProcessor> processor_;
 
   int samplerate_;
-  int numOutputChannels_;
+  int numDawChannels_{MAX_DAW_CHANNELS};
+  int numOutputChannels_{0};
   std::shared_ptr<ear::plugin::LevelMeterCalculator> levelMeter_;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EarMonitoringAudioProcessor)

--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
@@ -125,16 +125,9 @@ void SceneAudioProcessor::releaseResources() {}
 bool SceneAudioProcessor::isBusesLayoutSupported(
     const BusesLayout& layouts) const {
 
-  if(layouts.inputBuses.size() != 1)
-    return false;
-  if (layouts.inputBuses[0] !=
-      AudioChannelSet::discreteChannels(numDawChannels_))
-    return false;
+  auto i = layouts.getMainInputChannels();
+  return i == numDawChannels_;
 
-  if(layouts.outputBuses.size() != 0)
-    return false;
-
-  return true;
 }
 
 void SceneAudioProcessor::processBlock(AudioBuffer<float>& buffer,

--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
@@ -2,7 +2,6 @@
 #include "scene_plugin_editor.hpp"
 #include <adm/write.hpp>
 #include "programme_store_adm_serializer.hpp"
-#include <future>
 #include <programme_store.pb.h>
 #include "scene_backend.hpp"
 #include "metadata_event_dispatcher.hpp"
@@ -10,6 +9,9 @@
 #include "restored_pending_store.hpp"
 #include "reaper_vst3_interfaces.h"
 #include "reaper_integration.hpp"
+
+#include <future>
+#include <cassert>
 
 SceneAudioProcessor::SceneAudioProcessor()
     : AudioProcessor(
@@ -302,6 +304,7 @@ void SceneAudioProcessor::setIHostApplication(Steinberg::FUnknown* unknown) {
     numDawChannels_ = DetermineChannelCount(reaperHost);
     auto ret = setChannelLayoutOfBus(
         true, 0, AudioChannelSet::discreteChannels(numDawChannels_));
+    assert(ret);
     levelMeter_->setup(numDawChannels_, samplerate_);
   }
 }

--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.cpp
@@ -144,7 +144,7 @@ void SceneAudioProcessor::processBlock(AudioBuffer<float>& buffer,
     }
   } else {
     size_t sampleSize = sizeof(float);
-    uint8_t numChannels = numDawChannels_;
+    uint8_t numChannels = MAX_DAW_CHANNELS;
     size_t msg_size = buffer.getNumSamples() * numChannels * sampleSize;
 
     auto msg = std::make_shared<NngMsg>(msg_size);
@@ -156,9 +156,12 @@ void SceneAudioProcessor::processBlock(AudioBuffer<float>& buffer,
     int bufferChannels = buffer.getNumChannels();
     int bufferSamplesPerChannel = buffer.getNumSamples();
 
+    // TODO: We could do with a better system than sending channels of blanks,
+    // but at least this way we don't need to worry about DAW channel limits 
+    // and routings in to the Scene.
     for (int sample = 0; sample < bufferSamplesPerChannel; ++sample) {
       for (int channel = 0; channel < numChannels; ++channel) {
-        curSample = buffer.getSample(channel, sample);
+        curSample = channel < bufferChannels? buffer.getSample(channel, sample) : 0.f;
         assert(msgPosOffset + sampleSize <= msg_size);
         memcpy(msgPosPtr + msgPosOffset, &curSample, sampleSize);
         msgPosOffset += sampleSize;

--- a/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.hpp
+++ b/ear-production-suite-plugins/plugins/scene/src/scene_plugin_processor.hpp
@@ -10,6 +10,7 @@
 #include "ui_event_dispatcher.hpp"
 #include "communication/metadata_thread.hpp"
 #include "auto_mode_controller.hpp"
+#include <daw_channel_count.h>
 
 namespace ear {
 namespace plugin {
@@ -22,7 +23,7 @@ class RestoredPendingStore;
 }  // namespace plugin
 }  // namespace ear
 
-class SceneAudioProcessor : public AudioProcessor {
+class SceneAudioProcessor : public AudioProcessor, public VST3ClientExtensions {
  public:
   SceneAudioProcessor();
   ~SceneAudioProcessor();
@@ -62,6 +63,8 @@ class SceneAudioProcessor : public AudioProcessor {
 
   void setupBackend();
 
+  void setIHostApplication(Steinberg::FUnknown* unknown) override;
+
   ear::plugin::Metadata& metadata();
 
  private:
@@ -83,6 +86,7 @@ class SceneAudioProcessor : public AudioProcessor {
   SamplesSender* samplesSocket;
   bool sendSamplesToExtension{false};
   uint32_t samplerate_{0};
+  int numDawChannels_{MAX_DAW_CHANNELS};
 
   std::shared_ptr<ear::plugin::LevelMeterCalculator> levelMeter_;
   std::unique_ptr<ear::plugin::BackendSetupTimer> backendSetupTimer_;

--- a/reaper-adm-export-source-plugin/src/CMakeLists.txt
+++ b/reaper-adm-export-source-plugin/src/CMakeLists.txt
@@ -47,8 +47,9 @@ target_link_libraries(adm_export_source_VST3 PRIVATE
 
 target_include_directories(adm_export_source_VST3
     PRIVATE
+    ${CMAKE_SOURCE_DIR}/ear-production-suite-plugins/lib/include
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/submodules/readerwriterqueue>
-	$<TARGET_PROPERTY:adm,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:adm,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 target_compile_definitions(adm_export_source_VST3

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
@@ -373,9 +373,7 @@ void AdmStemPluginAudioProcessor::processBlock (AudioBuffer<float>& buffer, Midi
 bool AdmStemPluginAudioProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
     auto i = layouts.getMainInputChannels();
-    if (i != numDawChannels_) return false;
-
-    return true;
+    return i == numDawChannels_;
 }
 #endif
 

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.cpp
@@ -9,7 +9,7 @@
 AdmStemPluginAudioProcessor::AdmStemPluginAudioProcessor()
 #ifndef JucePlugin_PreferredChannelConfigurations
   : AudioProcessor (BusesProperties()
-         .withInput("Input", AudioChannelSet::discreteChannels(numDawChannels_), true)
+         .withInput("Input", AudioChannelSet::discreteChannels(MAX_DAW_CHANNELS), true)
      )
 #endif
 {

--- a/reaper-adm-export-source-plugin/src/PluginProcessor.h
+++ b/reaper-adm-export-source-plugin/src/PluginProcessor.h
@@ -15,6 +15,7 @@
 #include "PluginProcessorUtils.h"
 #include <functional>
 #include <memory>
+#include <daw_channel_count.h>
 
 #define TRACK_STATE 0
 #define DEBUG_PARAMS 0
@@ -27,7 +28,8 @@
 
 class AdmStemPluginAudioProcessorEditor;
 
-class AdmStemPluginAudioProcessor  : public AudioProcessor
+class AdmStemPluginAudioProcessor  : public AudioProcessor,
+    public VST3ClientExtensions
 {
 public:
     AdmStemPluginAudioProcessor();
@@ -57,7 +59,6 @@ public:
     void setCurrentProgram (int index) override;
     const String getProgramName (int index) override;
     void changeProgramName (int index, const String& newName) override;
-    void numChannelsChanged() override;
 
     void getStateInformation (MemoryBlock& destData) override;
     void setStateInformation (const void* data, int sizeInBytes) override;
@@ -79,8 +80,12 @@ public:
 
     void incomingMessage(std::shared_ptr<NngMsg> msg);
 
+    void setIHostApplication(Steinberg::FUnknown* unknown) override;
+
 private:
     AdmStemPluginAudioProcessorEditor* editor();
+
+    int numDawChannels_{ MAX_DAW_CHANNELS };
 
     int calcNumChannels();
     void updateNumChnsParam(bool force = false);


### PR DESCRIPTION
Setting `BusesProperties` in a `AudioProcessor` ctor sets the default layout for the plugin.
If this is 128 channels, REAPER v6.x will still instantiate the plugin and appear happy with it, but never call the `processBlock` method, so level monitoring, export and DSP will not run.
Therefore, it is necessary to know if we are running under REAPER with a 64 channel limitation within the plugins. The extension already provided an exposed function to do this, which could be called via the `DetermineChannelCount` helper. A handle to the host is grabbed via `setIHostApplication` - however, this is only called AFTER the plugin has been constructed, when we would need to set the default layout.
A bus can be resized at any time using the JUCE `setChannelLayoutOfBus` function. However, this always seems to return false if there is more than one bus in the layout (not sure if a bug in JUCE/VST3/REAPER, but it is a blocker in any case). For this reason, plugin layouts had to be changed to a single bus of `discreteChannels` so they can be resized after construction.
Additionally, there are some peculiarities with calls from the host to `isBusesLayoutSupported` - dozens of configurations are queried with quite unusual layout types. The actual set layout isn't always queried, so the calls would always return false. To simplify this, so long as the input and output channel counts match, we return true. Ultimately we're not bothered what the buses actually are as everything we do works entirely on a per-channel basis.