### PR TITLE
Fix #277 - Stack overflow in Bin Mon message handler

### DIFF
--- a/ear-production-suite-plugins/lib/include/binaural_monitoring_backend.hpp
+++ b/ear-production-suite-plugins/lib/include/binaural_monitoring_backend.hpp
@@ -68,7 +68,7 @@ class BinauralMonitoringBackend {
   bool isExporting() { return isExporting_; }
 
  private:
-  void onSceneReceived(proto::SceneStore store);
+  void onSceneReceived(const proto::SceneStore& store);
   void onConnection(communication::ConnectionId connectionId,
                     const std::string& streamEndpoint);
   void onConnectionLost();

--- a/ear-production-suite-plugins/lib/include/communication/monitoring_metadata_receiver.hpp
+++ b/ear-production-suite-plugins/lib/include/communication/monitoring_metadata_receiver.hpp
@@ -14,7 +14,7 @@ class SceneStore;
 namespace communication {
 class MonitoringMetadataReceiver {
  public:
-  using RequestHandler = std::function<void(proto::SceneStore)>;
+  using RequestHandler = std::function<void(const proto::SceneStore& store)>;
   MonitoringMetadataReceiver(std::shared_ptr<spdlog::logger> logger = nullptr);
   ~MonitoringMetadataReceiver();
   MonitoringMetadataReceiver(const MonitoringMetadataReceiver&) = delete;

--- a/ear-production-suite-plugins/lib/include/monitoring_backend.hpp
+++ b/ear-production-suite-plugins/lib/include/monitoring_backend.hpp
@@ -35,11 +35,11 @@ class MonitoringBackend {
   bool isExporting() { return isExporting_; }
 
  private:
-  void onSceneReceived(proto::SceneStore store);
+  void onSceneReceived(const proto::SceneStore& store);
   void onConnection(communication::ConnectionId connectionId,
                     const std::string& streamEndpoint);
   void onConnectionLost();
-  void updateActiveGains(proto::SceneStore store);
+  void updateActiveGains(const proto::SceneStore& store);
 
   std::shared_ptr<spdlog::logger> logger_;
   std::mutex gainsMutex_;

--- a/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
+++ b/ear-production-suite-plugins/lib/include/scene_gains_calculator.hpp
@@ -27,7 +27,7 @@ struct ItemGains {
 class SceneGainsCalculator {
  public:
   SceneGainsCalculator(Layout outputLayout, int inputChannelCount);
-  bool update(proto::SceneStore store);
+  bool update(const proto::SceneStore &store);
   Eigen::MatrixXf directGains();
   Eigen::MatrixXf diffuseGains();
 

--- a/ear-production-suite-plugins/lib/src/binaural_monitoring_backend.cpp
+++ b/ear-production-suite-plugins/lib/src/binaural_monitoring_backend.cpp
@@ -200,7 +200,8 @@ BinauralMonitoringBackend::getLatestObjectsTypeMetadata(ConnId id) {
   return std::optional<ObjectsEarMetadataAndRouting>();
 }
 
-void BinauralMonitoringBackend::onSceneReceived(proto::SceneStore store) {
+void BinauralMonitoringBackend::onSceneReceived(
+    const proto::SceneStore& store) {
   isExporting_ = store.has_is_exporting() && store.is_exporting();
 
   size_t totalDsChannels = 0;

--- a/ear-production-suite-plugins/lib/src/communication/monitoring_metadata_receiver.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/monitoring_metadata_receiver.cpp
@@ -65,10 +65,10 @@ void MonitoringMetadataReceiver::handleReceive(std::error_code ec,
       }
       // Called by NNG callback on thread with small stack.
       // Launch task in another thread to overcome stack limitation.
-      auto future = std::async(std::launch::async, [this, sceneStore]() {
+      auto future = std::async(std::launch::async, [this, sceneStore = std::move(sceneStore)]() {
         handler_(sceneStore);
       });
-      future.get();
+      future.get(); //blocking
     } catch (const std::runtime_error& e) {
       EAR_LOGGER_ERROR(
           logger_, "Failed to parse and dispatch scene metadata: {}", e.what());

--- a/ear-production-suite-plugins/lib/src/communication/monitoring_metadata_receiver.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/monitoring_metadata_receiver.cpp
@@ -65,7 +65,7 @@ void MonitoringMetadataReceiver::handleReceive(std::error_code ec,
       }
       // Called by NNG callback on thread with small stack.
       // Launch task in another thread to overcome stack limitation.
-      auto future = std::async(std::launch::async, [this, sceneStore = std::move(sceneStore)]() {
+      auto future = std::async(std::launch::async, [this, sceneStore]() {
         handler_(sceneStore);
       });
       future.get(); //blocking

--- a/ear-production-suite-plugins/lib/src/communication/monitoring_metadata_receiver.cpp
+++ b/ear-production-suite-plugins/lib/src/communication/monitoring_metadata_receiver.cpp
@@ -65,7 +65,7 @@ void MonitoringMetadataReceiver::handleReceive(std::error_code ec,
       }
       // Called by NNG callback on thread with small stack.
       // Launch task in another thread to overcome stack limitation.
-      auto future = std::async(std::launch::async, [this, sceneStore]() {
+      auto future = std::async(std::launch::async, [this, &sceneStore]() {
         handler_(sceneStore);
       });
       future.get(); //blocking

--- a/ear-production-suite-plugins/lib/src/monitoring_backend.cpp
+++ b/ear-production-suite-plugins/lib/src/monitoring_backend.cpp
@@ -47,9 +47,9 @@ MonitoringBackend::~MonitoringBackend() {
   controlConnection_.onConnectionEstablished(nullptr);
 }
 
-void MonitoringBackend::onSceneReceived(proto::SceneStore store) {
+void MonitoringBackend::onSceneReceived(const proto::SceneStore& store) {
   isExporting_ = store.has_is_exporting() && store.is_exporting();
-  updateActiveGains(std::move(store));
+  updateActiveGains(store);
 }
 
 GainHolder MonitoringBackend::currentGains() {
@@ -57,10 +57,10 @@ GainHolder MonitoringBackend::currentGains() {
   return gains_;
 }
 
-void MonitoringBackend::updateActiveGains(proto::SceneStore store) {
+void MonitoringBackend::updateActiveGains(const proto::SceneStore& store) {
   {
     std::lock_guard<std::mutex> lock(gainsCalculatorMutex_);
-    gainsCalculator_.update(std::move(store));
+    gainsCalculator_.update(store);
   }
   {
     std::lock_guard<std::mutex> lock(gainsMutex_);

--- a/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
+++ b/ear-production-suite-plugins/lib/src/scene_gains_calculator.cpp
@@ -51,7 +51,7 @@ SceneGainsCalculator::SceneGainsCalculator(ear::Layout outputLayout,
       totalOutputChannels{static_cast<int>(outputLayout.channels().size())},
       totalInputChannels{inputChannelCount} {}
 
-bool SceneGainsCalculator::update(proto::SceneStore store) {
+bool SceneGainsCalculator::update(const proto::SceneStore& store) {
   // First figure out what we need to process updates for
   std::vector<communication::ConnectionId> cachedIdsChecklist;
   cachedIdsChecklist.reserve(routingCache_.size());


### PR DESCRIPTION
As per #277, a crash would occur (probably only on windows) if the `AdmPresetDefinitionsHandler` was first instantiated as a singleton via an NNG message, due to the NNG threads having a small stack. We had previously overcome a similar issue in the LS monitoring plugins by wrapping `SceneGainsCalculator::update` code in a thread. I used a similar fix here, but it made sense for the thread launching to occur further up the call stack since for both the LS mons and Bin mon, the message handler call stems from `MonitoringMetadataReceiver::handleReceive`

LS mon call stack from message received to `SceneGainsCalculator::update` where a new thread would be launched:
```
	EAR Monitoring 9+10+3.vst3!ear::plugin::SceneGainsCalculator::update(ear::plugin::proto::SceneStore store) Line 56
 	EAR Monitoring 9+10+3.vst3!ear::plugin::MonitoringBackend::updateActiveGains(ear::plugin::proto::SceneStore store) Line 63
 	EAR Monitoring 9+10+3.vst3!ear::plugin::MonitoringBackend::onSceneReceived(ear::plugin::proto::SceneStore store) Line 52
 	[External Code]	
 	EAR Monitoring 9+10+3.vst3!ear::plugin::communication::MonitoringMetadataReceiver::handleReceive::__l9::<lambda_1>::operator()() Line 70
 	[External Code]	
 	EAR Binaural Monitoring.vst3!nng::detail::AsyncReadAction::operator()() Line 261
 	[External Code]	
 	EAR Binaural Monitoring.vst3!nng::AsyncIO::callback() Line 227
```

Bin mon call stack from message received to stack overflow (still on NNG thread)
```
	EAR Binaural Monitoring.vst3!__chkstk() Line 109	
 	EAR Binaural Monitoring.vst3!adm::xml::XmlParser::parse() Line 43
 	EAR Binaural Monitoring.vst3!adm::getCommonDefinitions() Line 163	
 	EAR Binaural Monitoring.vst3!adm::parseXml(std::basic_istream<char,std::char_traits<char>> & stream, adm::xml::ParserOptions options) Line 18
 	EAR Binaural Monitoring.vst3!AdmPresetDefinitionsHelper::AdmPresetDefinitionsHelper() Line 54
 	EAR Binaural Monitoring.vst3!AdmPresetDefinitionsHelper::getSingleton() Line 65
 	EAR Binaural Monitoring.vst3!ear::plugin::BinauralMonitoringBackend::onSceneReceived(ear::plugin::proto::SceneStore store) Line 228
 	[External Code]	
	EAR Binaural Monitoring.vst3!ear::plugin::communication::MonitoringMetadataReceiver::handleReceive(std::error_code ec, nng::Message message) Line 65
 	[External Code]	
 	EAR Binaural Monitoring.vst3!nng::detail::AsyncReadAction::operator()() Line 261
 	[External Code]	
 	EAR Binaural Monitoring.vst3!nng::AsyncIO::callback() Line 227
```

Fix was to launch message handlers in new threads from the common `MonitoringMetadataReceiver::handleReceive` method.

Closes #277