### PR TITLE
Don't do PDF timestamp check if running on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+TEST EDIT - DISCARD 
+
 UNRELEASED
 
 * Fix occasional crash bug in start up of Binaural Monitoring plugin [#277](https://github.com/ebu/ear-production-suite/issues/277) [#278](https://github.com/ebu/ear-production-suite/pull/278)

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -17,9 +17,11 @@ function(check_commit_timestamp_not_after SOURCE_FILE DEST_FILE)
     endif()
 endfunction()
 
-check_commit_timestamp_not_after(LICENSE.md LICENSE.pdf)
-check_commit_timestamp_not_after(${PROJECT_SOURCE_DIR}/CHANGELOG.md README.pdf)
-check_commit_timestamp_not_after(README.md.in README.pdf)
+if(NOT EPS_CI) # This prevents build failure if the runner generating the docs has a system time behind the system used to modify the MDs
+    check_commit_timestamp_not_after(LICENSE.md LICENSE.pdf)
+    check_commit_timestamp_not_after(${PROJECT_SOURCE_DIR}/CHANGELOG.md README.pdf)
+    check_commit_timestamp_not_after(README.md.in README.pdf)
+endif()
 
 add_custom_target(generate-package-docs
         COMMAND


### PR DESCRIPTION
Causes build failure if runner system clock is behind the clock of the system that modified the MDs