### PR TITLE
Workaround normalisation enabled during render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
 * Use ADM Coordinate Conversion lib over internal implementation [#293](https://github.com/ebu/ear-production-suite/issues/293) [#295](https://github.com/ebu/ear-production-suite/pull/295)
 * Remove support for 3rd-party plugin suites [#289](https://github.com/ebu/ear-production-suite/pull/289)
 * Update render dialog code to support latest version of REAPER (v7.34) [#296](https://github.com/ebu/ear-production-suite/issues/296) [#297](https://github.com/ebu/ear-production-suite/pull/297)
+* Give warning for older REAPER versions if user attempts to render with normalisation [#301](https://github.com/ebu/ear-production-suite/pull/301)
 
 Version 1.1.0b
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -180,7 +180,10 @@ void RenderDialogState::setCheckboxState(HWND hwnd, bool state)
 #ifdef WIN32
     SendMessage(hwnd, BM_CLICK, 0, 0);
 #else
+    auto parentHwnd = GetParent(hwnd);
+    auto controlId = GetWindowLong(hwnd, GWL_ID);
     SendMessage(hwnd, BM_SETCHECK, state ? BST_CHECKED : BST_UNCHECKED, 0);
+    SendMessage(parentHwnd, WM_COMMAND, MAKELONG(controlId, BN_CLICKED), (LPARAM)hwnd);
 #endif
 }
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -180,8 +180,7 @@ void RenderDialogState::setCheckboxState(HWND hwnd, bool state)
 #ifdef WIN32
     SendMessage(hwnd, BM_CLICK, 0, 0);
 #else
-    buttonWindowProc(hwnd, WM_LBUTTONDOWN, 0, 0);
-    buttonWindowProc(hwnd, WM_LBUTTONUP, 0, 0);
+    SendMessage(hwnd, BM_SETCHECK, state ? BST_CHECKED : BST_UNCHECKED, 0);
 #endif
 }
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -174,6 +174,9 @@ bool RenderDialogState::getCheckboxState(HWND hwnd)
 
 void RenderDialogState::setCheckboxState(HWND hwnd, bool state)
 {
+    auto currentState = getCheckboxState(hwnd);
+    if (state == currentState) return;
+    SendMessage(hwnd, BM_CLICK, 0, 0); // Have to simulate a click in case it has a listener attached to it
     SendMessage(hwnd, BM_SETCHECK, state? BST_CHECKED : BST_UNCHECKED, 0);
 }
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -8,7 +8,6 @@
 #include <helper/char_encoding.hpp>
 
 #define TIMER_ID 1
-#define BM_CLICK 0x00F5
 
 namespace {
 
@@ -177,8 +176,13 @@ void RenderDialogState::setCheckboxState(HWND hwnd, bool state)
 {
     auto currentState = getCheckboxState(hwnd);
     if (state == currentState) return;
-    SendMessage(hwnd, BM_CLICK, 0, 0); // Have to simulate a click in case it has a listener attached to it
-    SendMessage(hwnd, BM_SETCHECK, state? BST_CHECKED : BST_UNCHECKED, 0);
+    // Have to simulate a click in case it has a listener attached to it
+#ifdef WIN32
+    SendMessage(hwnd, BM_CLICK, 0, 0);
+#else
+    buttonWindowProc(hwnd, WM_LBUTTONDOWN, 0, 0);
+    buttonWindowProc(hwnd, WM_LBUTTONUP, 0, 0);
+#endif
 }
 
 void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -191,9 +191,6 @@ void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
     localise(EXPECTED_FIRST_CHANNEL_COUNT_COMBO_OPTION, reaperApi);
     localise(EXPECTED_PRESETS_BUTTON_TEXT, reaperApi);
     localise(EXPECTED_PRESERVE_SAMPLE_RATE_CHECKBOX_TEXT, reaperApi);
-    localise(EXPECTED_NORMALIZE_BUTTON_TEXT1, reaperApi);
-    localise(EXPECTED_NORMALIZE_BUTTON_TEXT2, reaperApi);
-    localise(EXPECTED_NORMALIZE_BUTTON_TEXT3, reaperApi);
     localise(EXPECTED_SECOND_PASS_CHECKBOX_TEXT, reaperApi);
     localise(EXPECTED_MONO2MONO_CHECKBOX_TEXT, reaperApi);
     localise(EXPECTED_MULTI2MULTI_CHECKBOX_TEXT, reaperApi);
@@ -204,12 +201,10 @@ void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
     localise(EXPECTED_FIRST_RESAMPLE_MODE_COMBO_OPTION, reaperApi);
 
     // Our dialog displayed - reset all vars (might not be the first time around)
-    lastFoundButtonHwnd.reset();
     boundsControlHwnd.reset();
     sourceControlHwnd.reset();
     presetsControlHwnd.reset();
     normalizeCheckboxControlHwnd.reset();
-    normalizeControlHwnd.reset();
     secondPassControlHwnd.reset();
     monoToMonoControlHwnd.reset();
     multiToMultiControlHwnd.reset();
@@ -220,6 +215,7 @@ void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)
     resampleModeControlHwnd.reset();
     sampleRateControlSetError = false;
     channelsControlSetError = false;
+    normalisationOptionsEnabled = false;
     sampleRateLastOption.clear();
     channelsLastOption.clear();
 
@@ -292,6 +288,17 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass1(HWND hwnd, LPARAM lP
             }
         }
 
+        if (controlType == BUTTON) {
+          // Normalise checkbox has no text, and order of control enumeration may not be reliable. Lets check ID.
+          // Do this in first pass as we don't want to disable the normalisation button if the checkbox isn't present.
+          if (GetWindowLong(hwnd, GWL_ID) == EXPECTED_NORMALIZE_CHECKBOX_ID) {
+            assert(getWindowText(hwnd) == "");
+            normalizeCheckboxControlHwnd = hwnd;
+            normalizeCheckboxLastState = getCheckboxState(hwnd);
+            setCheckboxState(hwnd, false);
+            EnableWindow(hwnd, false);
+          }
+        }
     }
 
     return true; // MUST return true to continue iterating through controls
@@ -314,41 +321,6 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lP
                 presetsControlHwnd = hwnd;
                 EnableWindow(hwnd, false);
             }
-
-            if (winStr == EXPECTED_NORMALIZE_BUTTON_TEXT1 || 
-              winStr == EXPECTED_NORMALIZE_BUTTON_TEXT2 ||
-              winStr == EXPECTED_NORMALIZE_BUTTON_TEXT3){
-                // This is the normalization config which will not work for this as we don't use the sink feed anyway - disable it
-                if (winStr == EXPECTED_NORMALIZE_BUTTON_TEXT3) {
-                    // This control has a seperate, unlabeled checkbox before it - see if we just passed it
-                    if (lastFoundButtonHwnd &&
-                      getControlType(*lastFoundButtonHwnd) == BUTTON &&
-                      getWindowText(*lastFoundButtonHwnd) == "") {
-                        normalizeCheckboxControlHwnd = lastFoundButtonHwnd;
-                        normalizeCheckboxLastState = getCheckboxState(*lastFoundButtonHwnd);
-                        setCheckboxState(*lastFoundButtonHwnd, false);
-                        EnableWindow(*lastFoundButtonHwnd, false);
-                    }
-                }
-                normalizeControlHwnd = hwnd;
-                EnableWindow(hwnd, false);
-            }
-            // Normalise button text changes depending on what options are enabled.
-            // Lets check ID too
-            if (id == EXPECTED_NORMALIZE_BUTTON_ID && !normalizeControlHwnd.has_value()) {
-              normalizeControlHwnd = hwnd;
-              EnableWindow(hwnd, false);
-            }
-            // Normalise checkbox has no text, and order of control enumeration may not be reliable.
-            // Lets check ID too
-            if (id == EXPECTED_NORMALIZE_CHECKBOX_ID && !normalizeCheckboxControlHwnd.has_value()) {
-              assert(winStr == "");
-              normalizeCheckboxControlHwnd = hwnd;
-              normalizeCheckboxLastState = getCheckboxState(hwnd);
-              setCheckboxState(hwnd, false);
-              EnableWindow(hwnd, false);
-            }
-
             if (winStr == EXPECTED_SECOND_PASS_CHECKBOX_TEXT){
                 // 2nd pass render causes a mismatch between expected number of received block and actual number of received blocks (double)
                 // Could probably be recified, but disable as quick fix for now
@@ -374,6 +346,11 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lP
               preserveSampleRateLastState = getCheckboxState(hwnd);
               setCheckboxState(hwnd, false);
               EnableWindow(hwnd, false);
+            }
+            // Normalise button text changes depending on what options are enabled. Lets check ID instead.
+            // We don't need to control this - just read it's text.
+            if (id == EXPECTED_NORMALIZE_BUTTON_ID) {
+              normalisationOptionsEnabled = winStr.ends_with("  ON");
             }
         }
 
@@ -407,9 +384,6 @@ BOOL CALLBACK RenderDialogState::prepareRenderControl_pass2(HWND hwnd, LPARAM lP
 
     }
 
-    if (controlType == BUTTON) {
-        lastFoundButtonHwnd = hwnd;
-    }
     return true; // MUST return true to continue iterating through controls
 }
 
@@ -585,15 +559,9 @@ WDL_DLGRET RenderDialogState::wavecfgDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wPa
           EnableWindow(*preserveSampleRateControlHwnd, true);
           setCheckboxState(*preserveSampleRateControlHwnd, preserveSampleRateLastState);
         }
-        if (normalizeControlHwnd) {
-          if (normalizeCheckboxControlHwnd) {
-            EnableWindow(*normalizeCheckboxControlHwnd, true);
-            setCheckboxState(*normalizeCheckboxControlHwnd, normalizeCheckboxLastState);
-            EnableWindow(*normalizeControlHwnd, normalizeCheckboxLastState); // Only reenable if last state was checked
-          }
-          else {
-            EnableWindow(*normalizeControlHwnd, true);
-          }
+        if (normalizeCheckboxControlHwnd) {
+          EnableWindow(*normalizeCheckboxControlHwnd, true);
+          setCheckboxState(*normalizeCheckboxControlHwnd, normalizeCheckboxLastState);
         }
 
         // NOTE: Sample Rate and Channels controls are;

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -177,14 +177,10 @@ void RenderDialogState::setCheckboxState(HWND hwnd, bool state)
     auto currentState = getCheckboxState(hwnd);
     if (state == currentState) return;
     // Have to simulate a click in case it has a listener attached to it
-#ifdef WIN32
-    SendMessage(hwnd, BM_CLICK, 0, 0);
-#else
     auto parentHwnd = GetParent(hwnd);
     auto controlId = GetWindowLong(hwnd, GWL_ID);
     SendMessage(hwnd, BM_SETCHECK, state ? BST_CHECKED : BST_UNCHECKED, 0);
     SendMessage(parentHwnd, WM_COMMAND, MAKELONG(controlId, BN_CLICKED), (LPARAM)hwnd);
-#endif
 }
 
 void RenderDialogState::startPreparingRenderControls(HWND hwndDlg)

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.cpp
@@ -8,6 +8,7 @@
 #include <helper/char_encoding.hpp>
 
 #define TIMER_ID 1
+#define BM_CLICK 0x00F5
 
 namespace {
 

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -43,8 +43,6 @@ private:
     std::shared_ptr<ReaperAPI> reaperApi;
     REAPER_PLUGIN_HINSTANCE reaperInst;
 
-    std::optional<HWND> lastFoundButtonHwnd{};
-
     std::optional<HWND> boundsControlHwnd{};
     std::optional<HWND> sourceControlHwnd{};
     std::optional<HWND> presetsControlHwnd{};
@@ -53,13 +51,13 @@ private:
     std::optional<HWND> channelsLabelHwnd{};
     std::optional<HWND> secondPassControlHwnd{};
     std::optional<HWND> normalizeCheckboxControlHwnd{};
-    std::optional<HWND> normalizeControlHwnd{};
     std::optional<HWND> resampleModeControlHwnd{};
     std::optional<HWND> monoToMonoControlHwnd{};
     std::optional<HWND> multiToMultiControlHwnd{};
     std::optional<HWND> preserveSampleRateControlHwnd{};
     bool sampleRateControlSetError{false};
     bool channelsControlSetError{false};
+    bool normalisationOptionsEnabled{false};
 
     std::string sampleRateLastOption{};
     std::string channelsLastOption{};
@@ -84,9 +82,6 @@ private:
     std::string EXPECTED_FIRST_CHANNEL_COUNT_COMBO_OPTION{ "Mono" };
     std::string EXPECTED_PRESETS_BUTTON_TEXT{ "Presets" };
     std::string EXPECTED_PRESERVE_SAMPLE_RATE_CHECKBOX_TEXT{ "Preserve source media sample rate if possible" };
-    std::string EXPECTED_NORMALIZE_BUTTON_TEXT1{ "Normalize/Limit..." };
-    std::string EXPECTED_NORMALIZE_BUTTON_TEXT2{ "Normalize/Limit/Fade" }; // Changed to include fade at ~v6.64
-    std::string EXPECTED_NORMALIZE_BUTTON_TEXT3{ "Normalize/fade" }; // Changed to remove limit at ~v7.34 - includes an unlabelled checkbox alongside
     const int EXPECTED_NORMALIZE_BUTTON_ID{ 1067 };
     const int EXPECTED_NORMALIZE_CHECKBOX_ID{ 1069 };
     std::string EXPECTED_SECOND_PASS_CHECKBOX_TEXT{ "2nd pass render" };

--- a/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
+++ b/reaper-adm-extension/src/reaper_adm/exportaction_dialogcontrol.h
@@ -51,6 +51,7 @@ private:
     std::optional<HWND> channelsLabelHwnd{};
     std::optional<HWND> secondPassControlHwnd{};
     std::optional<HWND> normalizeCheckboxControlHwnd{};
+    std::optional<HWND> normalizeControlHwnd{};
     std::optional<HWND> resampleModeControlHwnd{};
     std::optional<HWND> monoToMonoControlHwnd{};
     std::optional<HWND> multiToMultiControlHwnd{};


### PR DESCRIPTION
Having normalisation enabled during render will cause render to fail, since it does a multiple pass.

The fix currently implemented for v1.2 does not actually disable Normalisation if it was previously enabled. It seems that unchecking the normalisation checkbox (in later versions of REAPER ~v7.34) does not actually stop normalisation happening. We only seem to set the visual appearance of the checkbox. We must simulate a click to fire any listeners attached to the checkbox.

We still need a solution for previous versions of REAPER which do not have this checkbox. Normalisation is configured in a separate window, so we can't realistically control that. The best solution is probably just to show an error that render will fail due to normalisation being enabled.

