### PR TITLE
Update vcpkg to 2024.02.14

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -23,6 +23,7 @@
     "boost-program-options",
     "boost-property-tree",
     "boost-range",
+    "boost-rational",
     "boost-smart-ptr",
     "boost-test",
     "boost-timer",


### PR DESCRIPTION
This release of vcpkg fixes a bug where newer releases of VS 2022 (17.10+) weren't being detected ("error: in triplet x64-windows-static: unable to find a valid Visual Studio instance")

However bumping vcpkg version also means boost 1.84 rather than 1.83 was used. Something has changed between these two versions where boost-rational is no longer pulled down automatically (presumably it used to come down as part of boost-math). That is fixed by explicitly stating in vcpkg.json.