### PR TITLE
Fix CI build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,6 +68,10 @@
                     "type": "STRING",
                     "value": "x86_64"
                 },
+                "CMAKE_OSX_ARCHITECTURES": {
+                    "type": "STRING",
+                    "value": "x86_64"
+                },
                 "CMAKE_SYSTEM_NAME": {
                     "type": "STRING",
                     "value": "Darwin"

--- a/cmake_modules/FindJUCE.cmake
+++ b/cmake_modules/FindJUCE.cmake
@@ -49,7 +49,6 @@ find_package_handle_standard_args(JUCE
       find_library(COREMIDI CoreMidi)
       find_library(QUARTZCORE QuartzCore)
       find_library(IOKIT IOKit)
-      find_library(AGL AGL)
       find_library(ACCELERATE Accelerate)
       find_library(WEBKIT WebKit)
       find_library(OBJC objc)
@@ -69,7 +68,6 @@ find_package_handle_standard_args(JUCE
           ${COREMIDI}
           ${QUARTZCORE}
           ${IOKIT}
-          ${AGL}
           ${ACCELERATE}
           ${WEBKIT}
           ${OBJC}


### PR DESCRIPTION
- The AGL framework has been removed from macOS. It's also redundant, so remove from FindJUCE
- New versions of Clang fail to build older versions of fmt lib, which in turn was causing a build failure on spdlog usage on macOS. Update to the latest version of both via updating vcpkg 
- As an aside, discovered that attempting to crosscompile for x86_64 / macOS on an Apple Silicon mac was failing due to a missing CMake variable, so updated CMakePresets.txt to fix that.